### PR TITLE
Update JDT.setup to use github URIs for eclipse.jdt.core/ui

### DIFF
--- a/org.eclipse.jdt.releng/JDT.setup
+++ b/org.eclipse.jdt.releng/JDT.setup
@@ -13,6 +13,11 @@
     xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore"
     name="jdt"
     label="JDT">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+    <reference
+        href="JDTConfiguration.setup#/"/>
+  </annotation>
   <setupTask
       xsi:type="setup.p2:P2Task">
     <requirement
@@ -158,29 +163,23 @@
       label="Core">
     <setupTask
         xsi:type="git:GitCloneTask"
-        id="git.clone.jdt.core"
-        remoteURI="jdt/eclipse.jdt.core">
+        id="github.clone.jdt.core"
+        remoteURI="eclipse-jdt/eclipse.jdt.core">
       <annotation
           source="http://www.eclipse.org/oomph/setup/InducedChoices">
         <detail
             key="inherit">
-          <value>eclipse.git.gerrit.remoteURIs</value>
+          <value>github.remoteURIs</value>
         </detail>
         <detail
             key="label">
-          <value>JDT Features Git or Gerrit Repository</value>
+          <value>JDT Core Github Repository</value>
         </detail>
         <detail
             key="target">
           <value>remoteURI</value>
         </detail>
       </annotation>
-      <configSections
-          name="gerrit">
-        <properties
-            key="createchangeid"
-            value="true"/>
-      </configSections>
       <description>JDT Core</description>
     </setupTask>
     <setupTask
@@ -195,7 +194,7 @@
         <requirement
             name="org.eclipse.jdt.core.ecj.validation.plain.project"/>
         <sourceLocator
-            rootFolder="${git.clone.jdt.core.location}"/>
+            rootFolder="${github.clone.jdt.core.location}"/>
       </targlet>
     </setupTask>
     <setupTask
@@ -417,29 +416,23 @@
       label="UI">
     <setupTask
         xsi:type="git:GitCloneTask"
-        id="git.clone.jdt.ui"
-        remoteURI="jdt/eclipse.jdt.ui">
+        id="github.clone.jdt.core"
+        remoteURI="eclipse-jdt/eclipse.jdt.ui">
       <annotation
           source="http://www.eclipse.org/oomph/setup/InducedChoices">
         <detail
             key="inherit">
-          <value>eclipse.git.gerrit.remoteURIs</value>
+          <value>github.remoteURIs</value>
         </detail>
         <detail
             key="label">
-          <value>JDT UI Git or Gerrit Repository</value>
+          <value>JDT UI Github Repository</value>
         </detail>
         <detail
             key="target">
           <value>remoteURI</value>
         </detail>
       </annotation>
-      <configSections
-          name="gerrit">
-        <properties
-            key="createchangeid"
-            value="true"/>
-      </configSections>
       <description>JDT UI</description>
     </setupTask>
     <setupTask
@@ -452,7 +445,7 @@
         <requirement
             name="org.eclipse.jdt.jeview.feature.feature.group"/>
         <sourceLocator
-            rootFolder="${git.clone.jdt.ui.location}"/>
+            rootFolder="${github.clone.jdt.core.location}"/>
       </targlet>
     </setupTask>
     <setupTask

--- a/org.eclipse.jdt.releng/JDTConfiguration.setup
+++ b/org.eclipse.jdt.releng/JDTConfiguration.setup
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Configuration
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    label="JDT">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://www.eclipse.org/downloads/images/committers.png</value>
+    </detail>
+    <detail
+        key="badgeLabel">
+      <value>JDT</value>
+    </detail>
+  </annotation>
+  <installation
+      name="jdt.installation"
+      label="JDT Installation">
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="installation.id.default"
+        value="jdt"/>
+    <productVersion
+        href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.applications']/@products[name='eclipse.platform.sdk']/@versions[name='latest']"/>
+    <description>The JDT installation provides the latest tools needed to work with the Java Develop Tools's source code.</description>
+  </installation>
+  <workspace
+      name="jdt.workspace"
+      label="JDT Workspace">
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='core']/@projects[name='testbinaries']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='core']/@projects[name='tests']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='core']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='debug']/@projects[name='tests']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='debug']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='features']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='ui']/@projects[name='examples']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='ui']/@projects[name='tests']/@streams[name='master']"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='jdt']/@projects[name='ui']/@streams[name='master']"/>
+    <description>The JDT workspace provides the source code of the Java Development Tools.</description>
+  </workspace>
+  <description>
+    &lt;p>
+    The &lt;a href=&quot;https://www.eclipse.org/jdt/&quot;/>Java Development Tools&lt;/a> configuration provisions a dedicated development environment 
+    for the complete set of source projects of the &lt;a href=&quot;https://projects.eclipse.org/projects/eclipse.jdt&quot;>JDT project&lt;/a>.
+    &lt;/p>
+    &lt;p>
+    All the source projects from &lt;a href=&quot;https://github.com/eclipse-jdt&quot;>JDT's Github Repositories&lt;/a>
+    are available, organized into working sets, and ready for contribution.
+    &lt;/p>
+    &lt;/p>
+    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the analogous tutorial instructions&lt;/a> for the Eclipse Platform SDK's configuration for more details.
+    &lt;/p>
+  </description>
+</setup:Configuration>


### PR DESCRIPTION
Also provide JDTConfiguration.setup for simplified provisioning of a complete environment specifically for JDT development.

https://github.com/eclipse-jdt/eclipse.jdt/issues/3

This will allow for creating a link analogous to one:

https://github.com/eclipse-pde/.github/blob/main/CONTRIBUTING.md#create-an-eclipse-development-environment