### PR TITLE
Remove Orbit bundles as we use Central ones (cont'd)

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -181,13 +181,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.junit.jupiter.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="junit-jupiter-api"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Some forgotten Orbit bundles are now removed.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
