### PR TITLE
Update JDT feature for batch compiler

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt"
       label="%featureName"
-      version="3.18.1400.qualifier"
+      version="3.19.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -55,19 +55,10 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.jdt.compiler.apt"
+         id="org.eclipse.jdt.core.compiler.batch"
          download-size="0"
          install-size="0"
          version="0.0.0"
-         fragment="true"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jdt.compiler.tool"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         fragment="true"
          unpack="false"/>
 
    <plugin

--- a/org.eclipse.jdt-feature/pom.xml
+++ b/org.eclipse.jdt-feature/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt.feature</groupId>
   <artifactId>org.eclipse.jdt</artifactId>
-  <version>3.18.1400-SNAPSHOT</version>
+  <version>3.19.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <name>org eclipse jdt feature</name>
 

--- a/org.eclipse.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt; singleton:=true
-Bundle-Version: 3.18.1400.qualifier
+Bundle-Version: 3.19.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.intro;bundle-version="[3.2.0,4.0.0)",

--- a/org.eclipse.jdt/pom.xml
+++ b/org.eclipse.jdt/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt</artifactId>
-  <version>3.18.1400-SNAPSHOT</version>
+  <version>3.19.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <name>org eclipse jdt</name>
 


### PR DESCRIPTION
Added org.eclipse.jdt.compiler.batch

Removed fragments merged into batch compiler
 - org.eclipse.jdt.compiler.apt
 - org.eclipse.jdt.compiler.tool

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/181