### PR TITLE
Update git repo URLs to point to github in contributing guide

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -22,18 +22,17 @@ more.
 
 The project maintains the following source code repositories
 
-* http://git.eclipse.org/c/jdt/eclipse.jdt.core.binaries.git
-* http://git.eclipse.org/c/jdt/eclipse.jdt.core.git
-* http://git.eclipse.org/c/jdt/eclipse.jdt.debug.git
-* http://git.eclipse.org/c/jdt/eclipse.jdt.git
-* http://git.eclipse.org/c/jdt/eclipse.jdt.ui.git
+* https://github.com/eclipse-jdt/eclipse.jdt.core.binaries
+* https://github.com/eclipse-jdt/eclipse.jdt.core
+* https://github.com/eclipse-jdt/eclipse.jdt.debug
+* https://github.com/eclipse-jdt/eclipse.jdt
+* https://github.com/eclipse-jdt/eclipse.jdt.ui
 
-This project uses Bugzilla to track ongoing development and issues.
+This project uses Github to track ongoing development and issues.
+To search for issues or raise new ones, go to the respective project's
+issues section.
 
-* Search for issues: https://eclipse.org/bugs/buglist.cgi?product=JDT
-* Create a new report: https://eclipse.org/bugs/enter_bug.cgi?product=JDT
-
-Be sure to search for existing bugs before you create another one. Remember that
+Be sure to search for existing issues before you create another one. Remember that
 contributions are always welcome!
 
 ## Eclipse Contributor Agreement


### PR DESCRIPTION
Fixes issue #49 
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
