### PR TITLE
Update org.eclipse.jdt.annotation version in the JDT feature

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -86,7 +86,7 @@
          id="org.eclipse.jdt.annotation"
          download-size="0"
          install-size="0"
-         version="2.2.700.qualifier"
+         version="2.2.800.qualifier"
          unpack="false"/>
 
    <plugin


### PR DESCRIPTION
Fixes SDK build failure due the missing required bundle after https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1500 change.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1486
