### PR TITLE
Set project encoding to UTF-8

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
It was done using a "Quick Fix" and the value set (UTF-8) is the same value that any other project in the workspace uses. The objective of this commit is to declutter the "Problems" view.