### PR TITLE
Fix jdt feature include fo o.e.jdt.annotation

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -57,7 +57,7 @@
 
    <plugin
          id="org.eclipse.jdt.annotation"
-         version="2.2.800.qualifier"/>
+         version="2.2.900.qualifier"/>
 
    <plugin
          id="org.eclipse.jdt.core.manipulation"


### PR DESCRIPTION
Due to https://github.com/eclipse-jdt/eclipse.jdt.core/commit/ea61f08551d091b453020a83a00c5d75152cbb3e version had to be bumped via
https://github.com/eclipse-jdt/eclipse.jdt/commit/9a7d8f5b2d8661553040088ea68d6b4146b5e388 . But the feature includes v1 and v2 thus the versions are hardcoded. Thic commit changes the v2 hardcoded version to 2.2.900.

