### PR TITLE
Bump up version for org.eclipse.jdt.annotation

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -57,7 +57,7 @@
 
    <plugin
          id="org.eclipse.jdt.annotation"
-         version="2.2.900.qualifier"/>
+         version="2.3.0.qualifier"/>
 
    <plugin
          id="org.eclipse.jdt.core.manipulation"


### PR DESCRIPTION
See version update in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1716
