### PR TITLE
Use the ECJ generated compiler logs to parse compiler problems

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
 			post {
 				always {
 					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
-					publishIssues issues:[scanForIssues(tool: java()), scanForIssues(tool: mavenConsole())]
+					publishIssues issues:[scanForIssues(tool: eclipse(pattern: '**/target/compilelogs/*.xml')), scanForIssues(tool: mavenConsole())]
 				}
 			}
 		}


### PR DESCRIPTION
It is more reliable to pare a structured file than the log output.