### PR TITLE
Modify hello world cheatsheets to not create module-info.java

### DIFF
--- a/org.eclipse.jdt/cheatsheets/HelloWorld.xml
+++ b/org.eclipse.jdt/cheatsheets/HelloWorld.xml
@@ -16,7 +16,7 @@ If you need help at any step, click the (?) to the right. Let&apos;s get started
    </item>
    <item title="Create a Java project" dialog="true" skip="false" href="/org.eclipse.jdt.doc.user/concepts/concept-java-project.htm">
       <description>
-         Before creating a class, we need a project to put it in. In the main toolbar, click on the <b>New Java Project</b> button, or click on the link below. Enter <b>HelloWorld</b> for the project name, then	click <b>Finish</b>.
+         Before creating a class, we need a project to put it in. In the main toolbar, click on the <b>New Java Project</b> button, or click on the link below.  Click on the <b>Create module-info.java file</b> option checkbox to deselect it.   Enter <b>HelloWorld</b> for the project name, then	click <b>Finish</b>.
       </description>
       <command serialization="org.eclipse.ui.newWizard(newWizardId=org.eclipse.jdt.ui.wizards.JavaProjectWizard)" required="false" translate="">
       </command>

--- a/org.eclipse.jdt/cheatsheets/HelloWorldSWT.xml
+++ b/org.eclipse.jdt/cheatsheets/HelloWorldSWT.xml
@@ -69,7 +69,7 @@
       <description>
          Now we need a project to store our own source code. In the main
 			toolbar, click on the <b>New Java Project</b> button, or click on
-			the link below. Enter <b>HelloWorldSWT</b> for the project name,
+			the link below.  Click on the <b>Create module-info.java file</b> option checkbox to deselect it.  Enter <b>HelloWorldSWT</b> for the project name,
 			then click <b>Finish</b>.
       </description>
       <command serialization="org.eclipse.ui.newWizard(newWizardId=org.eclipse.jdt.ui.wizards.JavaProjectWizard)" required="false" translate="">


### PR DESCRIPTION
- modify the JDT hello world cheatsheets to add a step when creating the project to deselect the create module-info.java option
- fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1309

Change-Id: I509eacb486a553c1b1f240c2f680583d0d211931

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes hello world cheat sheets so that the example works.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
