### PR TITLE
Exclude converterJclMin and converterJclMin1.5 from the Oomph setup

### DIFF
--- a/org.eclipse.jdt.releng/JDT.setup
+++ b/org.eclipse.jdt.releng/JDT.setup
@@ -206,7 +206,14 @@
         <requirement
             name="*"/>
         <sourceLocator
-            rootFolder="${github.clone.jdt.core.location}"/>
+            rootFolder="${github.clone.jdt.core.location}">
+          <predicate
+              xsi:type="predicates:NotPredicate">
+            <operand
+                xsi:type="predicates:NamePredicate"
+                pattern="converterJclMin|converterJclMin1.5"/>
+          </predicate>
+        </sourceLocator>
       </targlet>
     </setupTask>
     <setupTask


### PR DESCRIPTION
- These don't compile with the latest JDT compiler