### PR TITLE
Include the latest Orbit milestone in the setup modular targlet

### DIFF
--- a/org.eclipse.jdt.releng/JDT.setup
+++ b/org.eclipse.jdt.releng/JDT.setup
@@ -103,6 +103,8 @@
           name="CBI">
         <repository
             url="https://download.eclipse.org/cbi/updates/license"/>
+        <repository
+            url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
       </repositoryList>
     </targlet>
   </setupTask>


### PR DESCRIPTION
@jukzi 

I tested the JDT setup all by itself today and it had problems resolving commonmark.  So like the other setups (PDE, Equinox, and Platform), it would be better to include the Orbit repository being used or soon to be used in the aggregator's *.target.