### PR TITLE
Fix hardcoded jdt.annotation version

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -57,7 +57,7 @@
 
    <plugin
          id="org.eclipse.jdt.annotation"
-         version="2.3.0.qualifier"/>
+         version="2.3.100.qualifier"/>
 
    <plugin
          id="org.eclipse.jdt.core.manipulation"


### PR DESCRIPTION
After bump for new stream I-build broke
https://ci.eclipse.org/releng/job/Builds/job/I-build-4.34/53/console

