### PR TITLE
[Oomph-Setup] Add reference to new jdt.core/debug/ui config setups

### DIFF
--- a/org.eclipse.jdt.releng/JDT.setup
+++ b/org.eclipse.jdt.releng/JDT.setup
@@ -173,6 +173,11 @@
   </project>
   <project name="core"
       label="Core">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+      <reference
+          href="https://raw.githubusercontent.com/eclipse-jdt/eclipse.jdt.core/master/org.eclipse.jdt.core.setup/JdtCoreConfiguration.setup#/"/>
+    </annotation>
     <setupTask
         xsi:type="git:GitCloneTask"
         id="github.clone.jdt.core"
@@ -350,6 +355,11 @@
   </project>
   <project name="debug"
       label="Debug">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+      <reference
+          href="https://raw.githubusercontent.com/eclipse-jdt/eclipse.jdt.debug/master/org.eclipse.jdt.debug.setup/JdtDebugConfiguration.setup#/"/>
+    </annotation>
     <setupTask
         xsi:type="git:GitCloneTask"
         id="github.clone.jdt.debug"
@@ -459,6 +469,11 @@
   </project>
   <project name="ui"
       label="UI">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+      <reference
+          href="https://raw.githubusercontent.com/eclipse-jdt/eclipse.jdt.ui/master/org.eclipse.jdt.ui.setup/JdtUIConfiguration.setup#/"/>
+    </annotation>
     <setupTask
         xsi:type="git:GitCloneTask"
         id="github.clone.jdt.ui"


### PR DESCRIPTION
## What it does
Add reference to new jdt.core/debug/ui config setups
Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2430

This should only be submitted after the following PRs are all submitted, otherwise [Oomph's setup-archiver job](https://ci.eclipse.org/oomph/job/setup-archiver/) will (probably) fail. See also https://github.com/eclipse-platform/eclipse.platform/pull/1582#issuecomment-2395971805.
- https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3071
- https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/533
- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1710


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
