### PR TITLE
Stop including including org.eclipse.jdt.annotation_v1

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -53,11 +53,7 @@
 
    <plugin
          id="org.eclipse.jdt.annotation"
-         version="1.2.100.qualifier"/>
-
-   <plugin
-         id="org.eclipse.jdt.annotation"
-         version="2.3.100.qualifier"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.jdt.core.manipulation"


### PR DESCRIPTION
This concludes the move of https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3029 and https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1712 by which are stopping to ship two versions of org.eclipse.jdt.annotation.

