### PR TITLE
Exclude org.eclipse.jdt.annotation_v1 from workspace in JDT.setup

### DIFF
--- a/org.eclipse.jdt.releng/JDT.setup
+++ b/org.eclipse.jdt.releng/JDT.setup
@@ -218,7 +218,7 @@
               xsi:type="predicates:NotPredicate">
             <operand
                 xsi:type="predicates:NamePredicate"
-                pattern="converterJclMin|converterJclMin1.5"/>
+                pattern="converterJclMin|converterJclMin1.5|org.eclipse.jdt.annotation_v1"/>
           </predicate>
         </sourceLocator>
       </targlet>


### PR DESCRIPTION
- This was removed from the the p2 repository and now has API errors if imported into the workspace.

