### PR TITLE
The setup JRE task should configure Java 21 now

### DIFF
--- a/org.eclipse.jdt.releng/JDT.setup
+++ b/org.eclipse.jdt.releng/JDT.setup
@@ -56,8 +56,8 @@
   </setupTask>
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-17"
-      location="${jre.location-17}"/>
+      version="JavaSE-21"
+      location="${jre.location-21}"/>
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"


### PR DESCRIPTION
The platform will require Java 21 to launch for the new release cycle:

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2654