### PR TITLE
Import JUnit 6 bundles

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -19,6 +19,17 @@
       %license
    </license>
 
+   <requires>
+      <import plugin="junit-jupiter-api" version="6" match="compatible"/>
+      <import plugin="junit-jupiter-engine" version="6" match="compatible"/>
+      <import plugin="junit-jupiter-params" version="6" match="compatible"/>
+      <import plugin="junit-platform-commons" version="6" match="compatible"/>
+      <import plugin="junit-platform-engine" version="6" match="compatible"/>
+      <import plugin="junit-platform-launcher" version="6" match="compatible"/>
+      <import plugin="junit-platform-suite-api" version="6" match="compatible"/>
+      <import plugin="junit-platform-suite-engine" version="6" match="compatible"/>
+   </requires>
+
    <plugin
          id="org.eclipse.jdt"
          version="0.0.0"/>


### PR DESCRIPTION
Currently the JUnit 6 Classpathcontainer is empty unless one installs the JUnit bundles into the IDE (what is not really feasible to expect).

This now adds the JUnit 6 bundles as imports to make them install whenever the junit support is installed.

FYI @merks @akurtakov @trancexpress @iloveeclipse 