### PR TITLE
Clean up SVG images

### DIFF
--- a/org.eclipse.jdt/eclipse32.svg
+++ b/org.eclipse.jdt/eclipse32.svg
@@ -7,13 +7,6 @@
    viewBox="0 0 2.7234042 2.7234042"
    version="1.1"
    id="SVGRoot"
-   sodipodi:docname="eclipse32.svg"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96"
-   inkscape:version="1.3 (0e150ed, 2023-07-21)"
-   inkscape:export-filename="eclipse32.png"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -73,39 +66,6 @@
          id="stop48" />
     </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#8b8b8b"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="19.955631"
-     inkscape:cx="8.0177872"
-     inkscape:cy="15.384129"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1027"
-     inkscape:window-x="0"
-     inkscape:window-y="25"
-     inkscape:window-maximized="1"
-     inkscape:grid-bbox="true"
-     showguides="false"
-     inkscape:pagecheckerboard="0"
-     inkscape:showpageshadow="0"
-     inkscape:deskcolor="#505050">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2674"
-       originx="0"
-       originy="0"
-       spacingy="1"
-       spacingx="1"
-       units="px"
-       visible="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata1981">
     <rdf:RDF>
@@ -118,63 +78,50 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
      id="layer1">
     <path
        d="M 0.62737081,1.1063823 H 0.43526716 c -0.007028,0.055477 -0.0118169,0.1121088 -0.0139899,0.1701839 H 0.64959642 0.76412945 2.4173353 2.5682392 c -0.0022,-0.058075 -0.00697,-0.1147067 -0.014063,-0.1701839"
        id="path4"
-       inkscape:connector-curvature="0"
        style="fill:#2c2255;stroke-width:0.144079" />
     <path
        d="m 0.44092995,1.4468076 c 0.00215,0.058114 0.00686,0.1147552 0.0138298,0.1702125 h 0.1974322 0.14964812 1.59890983 0.1486275 c 0.007,-0.055458 0.011762,-0.1120989 0.013942,-0.1702125"
        id="path6"
-       inkscape:connector-curvature="0"
        style="fill:#2c2255;stroke-width:0.143262" />
     <path
-       inkscape:connector-curvature="0"
        style="fill:#2c2255;stroke-width:0.132772"
        d="M 0.82690487,1.7021281 H 0.4562943 C 0.505366,1.8646102 0.59642396,2.0102357 0.72973708,2.13894 0.94226706,2.3441095 1.1978255,2.4465559 1.4966776,2.4465559 c 0.059739,0 0.1176203,-0.0043 0.1738404,-0.01248 C 1.89562,2.4012859 2.0926998,2.303046 2.2615598,2.1389402 2.3957359,2.0102763 2.4874371,1.8646106 2.5368841,1.7021282 H 2.3864847 2.1665616 Z"
        id="path2" />
     <path
-       inkscape:connector-curvature="0"
        style="fill:#2c2255;stroke-width:0.132615"
        d="M 2.5337307,0.99982932 C 2.4844544,0.83688047 2.3929672,0.69055553 2.2590699,0.56094 2.0910856,0.39835447 1.8950636,0.30081153 1.6712688,0.26799105 c -0.056605,-0.008308 -0.1149107,-0.012672 -0.1751144,-0.012672 -0.298084,0 -0.55300775,0.10190115 -0.7649694,0.30561987 -0.1330134,0.12961533 -0.22388345,0.27594043 -0.27280603,0.4388893"
        id="path10" />
     <path
        d="M 0.84343884,0.93616972 H 0.48728386 C 0.47557735,0.99159172 0.46802581,1.048443 0.46077447,1.1063822 H 0.64421001 0.8004043 2.1921242 2.3892232 2.5300959 C 2.5228203,1.0484742 2.5134498,0.99162252 2.5017788,0.93616972"
        id="path57"
-       inkscape:connector-curvature="0"
        style="fill:#ffffff;stroke-width:0.146677" />
     <path
        d="M 2.2377713,1.2765662 C 2.2341513,1.2182316 2.2266113,1.1613399 2.2153933,1.1063823 H 0.78888378 c -0.011234,0.054929 -0.018774,0.1118201 -0.0224006,0.1701839 z"
        id="path37"
-       inkscape:connector-curvature="0"
        style="fill:url(#SVGID_1_);stroke-width:0.144573" />
     <path
        d="M 2.2377075,1.4468076 H 0.76649315 c 0.003626,0.058345 0.011122,0.1152458 0.0223776,0.1702125 H 2.2153519 c 0.01124,-0.054967 0.01872,-0.1118679 0.022356,-0.1702125 z"
        id="path44"
-       inkscape:connector-curvature="0"
        style="fill:url(#SVGID_2_);stroke-width:0.144583" />
     <path
        d="m 1.503658,2.1140691 c 0.3027925,0 0.5637948,-0.1686359 0.6839895,-0.4119424 H 0.81966858 C 0.93986352,1.9454336 1.2008657,2.1140691 1.503658,2.1140691 Z"
        id="path51"
-       inkscape:connector-curvature="0"
        style="fill:url(#SVGID_3_);stroke-width:0.133164" />
     <path
        d="M 0.66694898,1.4468074 H 0.77345496 2.2281205 2.4192171 2.5643858 c 10e-4,-0.027074 0.00157,-0.054334 0.00157,-0.08178 0,-0.029685 -7.634e-4,-0.059121 -0.00195,-0.088432 H 2.4191943 2.2280987 0.77343311 0.65940372 0.43402718 c -0.001177,0.029281 -0.001942,0.058748 -0.001942,0.088432 0,0.027447 5.67e-4,0.054707 0.00157,0.08178 z"
        id="path55"
-       inkscape:connector-curvature="0"
        style="fill:#ffffff;stroke-width:0.148948" />
     <path
        d="M 2.3764373,1.6170203 H 2.1826736 0.81452295 0.66831161 0.47511889 c 0.006938,0.057908 0.0148292,0.1147289 0.0261454,0.1702127 H 0.85678709 2.1404094 2.3511381 2.4883794 C 2.4996673,1.73178 2.5087916,1.6749596 2.5157506,1.6170203 Z"
        id="path59"
-       inkscape:connector-curvature="0"
        style="fill:#ffffff;stroke-width:0.145657" />
     <path
        d="m 0.33321635,1.3466565 c 0,-0.59449504 0.43835624,-1.08845737 1.00861495,-1.17533874 -0.014148,-5.295e-4 -0.028365,-0.001105 -0.042649,-0.001105 -0.63993915,0 -1.15875676,0.52672127 -1.15875676,1.17644374 0,0.649746 0.51879501,1.1764441 1.15875676,1.1764441 0.01433,0 0.028546,-5.524e-4 0.042739,-0.00108 C 0.77157259,2.4351371 0.33321635,1.9411748 0.33321635,1.3466565 Z"
        id="path12"
-       inkscape:connector-curvature="0"
        style="fill:#f7941e;stroke-width:0.133164" />
     <ellipse
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.0713786;stroke-linecap:square;stroke-miterlimit:3;stroke-opacity:0.921569"

--- a/org.eclipse.jdt/images/topiclabel/ov_javadev48.svg
+++ b/org.eclipse.jdt/images/topiclabel/ov_javadev48.svg
@@ -2,21 +2,17 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    id="svg8106"
    width="48"
    height="48"
    viewBox="0 0 48 48"
-   sodipodi:docname="ov_javadev48.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata8112">
     <rdf:RDF>
@@ -31,498 +27,16 @@
   </metadata>
   <defs
      id="defs8110">
-    <linearGradient
-       id="linearGradient4541"
-       inkscape:collect="always">
-      <stop
-         id="stop4543"
-         offset="0"
-         style="stop-color:#a1adb2;stop-opacity:1" />
-      <stop
-         id="stop4545"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4972"
-       inkscape:collect="always">
-      <stop
-         id="stop4974"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop4976"
-         offset="1"
-         style="stop-color:#f5f8fd;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4964"
-       inkscape:collect="always">
-      <stop
-         id="stop4966"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop4968"
-         offset="1"
-         style="stop-color:#e8eefa;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4956"
-       inkscape:collect="always">
-      <stop
-         id="stop4958"
-         offset="0"
-         style="stop-color:#fcfdfe;stop-opacity:1" />
-      <stop
-         id="stop4960"
-         offset="1"
-         style="stop-color:#dee6f8;stop-opacity:1" />
-    </linearGradient>
     <filter
-       id="filter8854"
-       inkscape:label="Drop Shadow"
-       style="color-interpolation-filters:sRGB">
-      <feFlood
-         id="feFlood8856"
-         result="flood"
-         flood-color="rgb(244,248,254)"
-         flood-opacity="0.933333" />
-      <feComposite
-         id="feComposite8858"
-         result="composite1"
-         operator="in"
-         in2="SourceGraphic"
-         in="flood" />
-      <feGaussianBlur
-         id="feGaussianBlur8860"
-         result="blur"
-         stdDeviation="1.2"
-         in="composite1" />
-      <feOffset
-         id="feOffset8862"
-         result="offset"
-         dy="3"
-         dx="-1" />
-      <feComposite
-         id="feComposite8864"
-         result="composite2"
-         operator="over"
-         in2="offset"
-         in="SourceGraphic" />
-    </filter>
-    <linearGradient
-       id="linearGradient6122">
-      <stop
-         id="stop6124"
-         offset="0"
-         style="stop-color:#c0c0c0;stop-opacity:1" />
-      <stop
-         style="stop-color:#adadad;stop-opacity:1"
-         offset="0.5"
-         id="stop6132" />
-      <stop
-         id="stop6126"
-         offset="1"
-         style="stop-color:#808080;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7087">
-      <stop
-         id="stop7089"
-         offset="0"
-         style="stop-color:#17325d;stop-opacity:1;" />
-      <stop
-         style="stop-color:#b4d0e2;stop-opacity:1"
-         offset="0.25"
-         id="stop7091" />
-      <stop
-         style="stop-color:#b7d2e4;stop-opacity:1"
-         offset="0.5"
-         id="stop7093" />
-      <stop
-         id="stop7095"
-         offset="0.75"
-         style="stop-color:#acc9de;stop-opacity:1" />
-      <stop
-         id="stop7097"
-         offset="1"
-         style="stop-color:#3e72a7;stop-opacity:1" />
-    </linearGradient>
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask7366">
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path7368"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-    </mask>
-    <linearGradient
-       id="linearGradient7584-5">
-      <stop
-         style="stop-color:#f9cd5f;stop-opacity:1"
-         offset="0"
-         id="stop7586-4" />
-      <stop
-         style="stop-color:#fbf0b4;stop-opacity:1"
-         offset="1"
-         id="stop7588-5" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7592-1">
-      <stop
-         style="stop-color:#bd8416;stop-opacity:1"
-         offset="0"
-         id="stop7594-6" />
-      <stop
-         style="stop-color:#a66b10;stop-opacity:1"
-         offset="1"
-         id="stop7596-9" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
-      <stop
-         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1"
-         offset="0"
-         style="stop-color:#5aad60;stop-opacity:1;" />
-      <stop
-         style="stop-color:#5bb26a;stop-opacity:1;"
-         offset="0.5"
-         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9" />
-      <stop
-         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0"
-         offset="1"
-         style="stop-color:#a4c589;stop-opacity:1" />
-    </linearGradient>
-    <mask
-       id="mask7366-4"
-       maskUnits="userSpaceOnUse">
-      <path
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         id="path7368-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccc" />
-    </mask>
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-20,0)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9331"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9333"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-18,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9335"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-16,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9337"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-14,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9339"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-12,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4956"
-       id="linearGradient68073"
-       x1="88.220117"
-       y1="1042.7973"
-       x2="163.22012"
-       y2="1042.7973"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4964"
-       id="linearGradient68075"
-       x1="94.469681"
-       y1="1032.2668"
-       x2="163.22012"
-       y2="1032.2669"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4972"
-       id="linearGradient68077"
-       x1="88.220116"
-       y1="1032.2668"
-       x2="152.72206"
-       y2="1032.2668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <filter
-       style="color-interpolation-filters:sRGB"
-       inkscape:label="Drop Shadow"
-       id="filter8854-9">
-      <feFlood
-         flood-opacity="0.933333"
-         flood-color="rgb(244,248,254)"
-         result="flood"
-         id="feFlood8856-0" />
-      <feComposite
-         in="flood"
-         in2="SourceGraphic"
-         operator="in"
-         result="composite1"
-         id="feComposite8858-2" />
-      <feGaussianBlur
-         in="composite1"
-         stdDeviation="1.2"
-         result="blur"
-         id="feGaussianBlur8860-3" />
-      <feOffset
-         dx="-1"
-         dy="3"
-         result="offset"
-         id="feOffset8862-2" />
-      <feComposite
-         in="SourceGraphic"
-         in2="offset"
-         operator="over"
-         result="composite2"
-         id="feComposite8864-3" />
-    </filter>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
-      <stop
-         style="stop-color:#7564b1;stop-opacity:1"
-         offset="0"
-         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
-      <stop
-         id="stop10806-6-8-5-3-9-24-8-4-3-2"
-         offset="0.5"
-         style="stop-color:#5d4aa1;stop-opacity:1" />
-      <stop
-         style="stop-color:#9283c3;stop-opacity:1"
-         offset="1"
-         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7540-2-3-8-7">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop7542-8-7-5-3" />
-      <stop
-         id="stop7544-8-2-0-5"
-         offset="0.47623286"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop7546-1-7-9-5"
-         offset="0.5"
-         style="stop-color:#ffffff;stop-opacity:0" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop7548-98-9-2-4" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7272-66-4-5-5-5-8"
-       inkscape:collect="always">
-      <stop
-         id="stop7274-6-0-1-7-4-7"
-         offset="0"
-         style="stop-color:#8f6c10;stop-opacity:1" />
-      <stop
-         id="stop7276-66-6-3-9-1-4"
-         offset="1"
-         style="stop-color:#c9a645;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       id="linearGradient10540"
-       gradientUnits="userSpaceOnUse"
-       x1="-22.453552"
-       y1="1030.3411"
-       x2="-10.159802"
-       y2="1030.3411" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       id="linearGradient10542"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
-       x1="-22.453552"
-       y1="1030.3411"
-       x2="-10.159802"
-       y2="1030.3411" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7272-66-4-5-5-5-8"
-       id="linearGradient10544"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
-       x1="-15.945988"
-       y1="1037.4661"
-       x2="-15.945988"
-       y2="1023.2569" />
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask10620">
-      <path
-         sodipodi:type="arc"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
-         id="path10622"
-         sodipodi:cx="388.125"
-         sodipodi:cy="468.23718"
-         sodipodi:rx="10.625"
-         sodipodi:ry="10.625"
-         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
-         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)" />
-    </mask>
-    <linearGradient
-       id="linearGradient4528-9-5-7-9-7-3">
-      <stop
-         style="stop-color:#e0c576;stop-opacity:1;"
-         offset="0"
-         id="stop4530-0-5-0-5-8-4" />
-      <stop
-         style="stop-color:#9e7916;stop-opacity:1"
-         offset="1"
-         id="stop4532-7-9-3-3-6-1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
-      <stop
-         id="stop6283-0-2-2-1-2-0-1-6-0"
-         offset="0"
-         style="stop-color:#f7f9fb;stop-opacity:1" />
-      <stop
-         id="stop6285-5-0-9-7-6-9-9-1-9"
-         offset="1"
-         style="stop-color:#ffd680;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3827">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="0"
-         id="stop3829" />
-      <stop
-         id="stop3835"
-         offset="0.60149658"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop3831" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
-      <stop
-         style="stop-color:#f3faed;stop-opacity:1"
-         offset="0"
-         id="stop10800-5-2-1-8-20-6-4-9-8-2-9" />
-      <stop
-         id="stop10806-6-8-5-3-9-24-8-4-3-2-4"
-         offset="0.65917557"
-         style="stop-color:#e7f4da;stop-opacity:1" />
-      <stop
-         style="stop-color:#67bf1f;stop-opacity:1"
-         offset="1"
-         id="stop10802-1-5-3-0-4-8-4-2-9-2-5" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)"
-       gradientUnits="userSpaceOnUse"
-       y2="1008.3622"
-       x2="60"
-       y1="1007.8622"
-       x1="41"
-       id="linearGradient5885"
-       xlink:href="#linearGradient4541"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient11146-4-4-4-6-2">
-      <stop
-         style="stop-color:#faefba;stop-opacity:1"
-         offset="0"
-         id="stop11150-4-72-3-9-7" />
-      <stop
-         id="stop11152-9-0-7-3-8"
-         offset="1"
-         style="stop-color:#9e6542;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10507">
-      <stop
-         id="stop10509"
-         offset="0"
-         style="stop-color:#5f392d;stop-opacity:1" />
-      <stop
-         style="stop-color:#9e7058;stop-opacity:1"
-         offset="0.18181793"
-         id="stop10511" />
-      <stop
-         style="stop-color:#794f40;stop-opacity:1"
-         offset="0.36363617"
-         id="stop10513" />
-      <stop
-         style="stop-color:#794f40;stop-opacity:1"
-         offset="0.49999985"
-         id="stop10515" />
-      <stop
-         style="stop-color:#794f40;stop-opacity:1"
-         offset="0.63636351"
-         id="stop10517" />
-      <stop
-         id="stop10519"
-         offset="0.81818175"
-         style="stop-color:#9e7058;stop-opacity:1" />
-      <stop
-         id="stop10522"
-         offset="1"
-         style="stop-color:#5f392d;stop-opacity:1" />
-    </linearGradient>
-    <filter
-       height="2.3759999"
-       y="-0.68800002"
+       height="2.376"
+       y="-0.68799998"
        width="1.8256"
-       x="-0.41280001"
+       x="-0.41279999"
        id="filter5309-8"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5311-9"
-         stdDeviation="2.58"
-         inkscape:collect="always" />
+         stdDeviation="2.58" />
     </filter>
     <linearGradient
        gradientUnits="userSpaceOnUse"
@@ -532,11 +46,9 @@
        x1="18.4132"
        id="linearGradient5379"
        xlink:href="#linearGradient5373"
-       inkscape:collect="always"
        gradientTransform="matrix(0.60902244,0,0,0.61163793,6.7955933,-593.25521)" />
     <linearGradient
-       id="linearGradient5373"
-       inkscape:collect="always">
+       id="linearGradient5373">
       <stop
          id="stop5375"
          offset="0"
@@ -547,56 +59,48 @@
          style="stop-color:#68c024;stop-opacity:1" />
     </linearGradient>
     <filter
-       height="2.1385217"
-       y="-0.56926084"
-       width="1.9680701"
-       x="-0.48403507"
+       height="2.1385268"
+       y="-0.56926341"
+       width="1.96807"
+       x="-0.484035"
        id="filter5535"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5537"
-         stdDeviation="5.2543488"
-         inkscape:collect="always" />
+         stdDeviation="5.2543488" />
     </filter>
     <filter
        height="1.140416"
-       y="-0.070208006"
+       y="-0.070208004"
        width="1.2166662"
-       x="-0.10833312"
+       x="-0.1083331"
        id="filter5221"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5223"
-         stdDeviation="0.8812897"
-         inkscape:collect="always" />
+         stdDeviation="0.8812897" />
     </filter>
     <filter
-       height="1.0771819"
-       y="-0.038590964"
-       width="1.2955548"
-       x="-0.14777733"
+       height="1.0982566"
+       y="-0.049128299"
+       width="1.1228843"
+       x="-0.061442132"
        id="filter5047"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5049"
-         stdDeviation="0.44094492"
-         inkscape:collect="always" />
+         stdDeviation="0.44094492" />
     </filter>
     <filter
-       height="1.0771819"
-       y="-0.038590964"
-       width="1.2955548"
-       x="-0.14777733"
+       height="1.1533777"
+       y="-0.07668885"
+       width="1.1574636"
+       x="-0.0787318"
        id="filter5047-9"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5049-4"
-         stdDeviation="0.44094492"
-         inkscape:collect="always" />
+         stdDeviation="0.44094492" />
     </filter>
     <linearGradient
        gradientUnits="userSpaceOnUse"
@@ -606,11 +110,9 @@
        x1="18.4132"
        id="linearGradient5379-8"
        xlink:href="#linearGradient5373-7"
-       inkscape:collect="always"
        gradientTransform="matrix(0.63222452,0,0,0.63493274,-1.2789143,-623.68285)" />
     <linearGradient
-       id="linearGradient5373-7"
-       inkscape:collect="always">
+       id="linearGradient5373-7">
       <stop
          id="stop5375-1"
          offset="0"
@@ -622,56 +124,39 @@
     </linearGradient>
     <filter
        height="1.140416"
-       y="-0.070208006"
+       y="-0.070208004"
        width="1.2166662"
        x="-0.10833312"
        id="filter5221-5"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5223-0"
-         stdDeviation="0.8812897"
-         inkscape:collect="always" />
+         stdDeviation="0.8812897" />
     </filter>
     <filter
-       height="1.0771819"
-       y="-0.038590964"
-       width="1.2955548"
-       x="-0.14777733"
+       height="1.0982566"
+       y="-0.049128299"
+       width="1.1228843"
+       x="-0.061442132"
        id="filter5047-7"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5049-1"
-         stdDeviation="0.44094492"
-         inkscape:collect="always" />
+         stdDeviation="0.44094492" />
     </filter>
     <filter
-       height="1.0771819"
-       y="-0.038590964"
-       width="1.2955548"
-       x="-0.14777733"
+       height="1.1533777"
+       y="-0.07668885"
+       width="1.1574636"
+       x="-0.0787318"
        id="filter5047-9-2"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5049-4-2"
-         stdDeviation="0.44094492"
-         inkscape:collect="always" />
+         stdDeviation="0.44094492" />
     </filter>
     <linearGradient
-       gradientTransform="matrix(0.59029206,0,0,0.59029867,-187.39714,-247.59876)"
-       gradientUnits="userSpaceOnUse"
-       y2="467.72714"
-       x2="392.85153"
-       y1="432.15189"
-       x1="357.27591"
-       id="linearGradient10579-0"
-       xlink:href="#linearGradient10573-4"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient10573-4"
-       inkscape:collect="always">
+       id="linearGradient10573-4">
       <stop
          id="stop10575-8"
          offset="0"
@@ -689,8 +174,7 @@
        x1="355.2973"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4895-6"
-       xlink:href="#linearGradient4368"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4368" />
     <linearGradient
        id="linearGradient4368">
       <stop
@@ -730,8 +214,7 @@
        x1="355.2973"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4895-8"
-       xlink:href="#linearGradient4368"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4368" />
     <radialGradient
        r="6.1875"
        fy="442.21997"
@@ -741,8 +224,7 @@
        gradientTransform="matrix(2.8766703,-5.4759397e-6,4.789504e-6,2.5328626,-1084.6557,-1106.6972)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient10505-4"
-       xlink:href="#linearGradient11146-4-4-4-6-2-8"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient11146-4-4-4-6-2-8" />
     <linearGradient
        id="linearGradient11146-4-4-4-6-2-8">
       <stop
@@ -755,137 +237,116 @@
          style="stop-color:#ad6e48;stop-opacity:1" />
     </linearGradient>
     <filter
-       height="2.3759999"
-       y="-0.68800002"
-       width="1.8256"
-       x="-0.41280001"
+       height="2.5549992"
+       y="-0.7774996"
+       width="1.9329995"
+       x="-0.46649976"
        id="filter5309-8-8"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5311-9-0"
-         stdDeviation="2.58"
-         inkscape:collect="always" />
+         stdDeviation="2.58" />
     </filter>
     <filter
-       height="2.1385217"
-       y="-0.56926084"
-       width="1.9680701"
-       x="-0.48403507"
+       height="2.2113769"
+       y="-0.60568846"
+       width="2.0300132"
+       x="-0.51500661"
        id="filter5535-3-5"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5537-2-8"
-         stdDeviation="5.2543488"
-         inkscape:collect="always" />
+         stdDeviation="5.2543488" />
     </filter>
     <filter
-       height="1.140416"
-       y="-0.070208006"
-       width="1.2166662"
-       x="-0.10833312"
+       height="1.1677718"
+       y="-0.079699564"
+       width="1.2477325"
+       x="-0.11231911"
        id="filter5221-5-8"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5223-0-5"
-         stdDeviation="0.8812897"
-         inkscape:collect="always" />
+         stdDeviation="0.8812897" />
     </filter>
     <filter
-       height="1.0771819"
-       y="-0.038590964"
-       width="1.2955548"
-       x="-0.14777733"
+       height="1.1269541"
+       y="-0.052982524"
+       width="1.1648626"
+       x="-0.072275"
        id="filter5047-7-2"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5049-1-3"
-         stdDeviation="0.44094492"
-         inkscape:collect="always" />
+         stdDeviation="0.44094492" />
     </filter>
     <filter
-       height="1.0771819"
-       y="-0.038590964"
-       width="1.2955548"
-       x="-0.14777733"
+       height="1.2021495"
+       y="-0.087124538"
+       width="1.2180956"
+       x="-0.09933736"
        id="filter5047-9-2-9"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5049-4-2-2"
-         stdDeviation="0.44094492"
-         inkscape:collect="always" />
+         stdDeviation="0.44094492" />
     </filter>
     <filter
-       height="2.1385217"
-       y="-0.56926084"
-       width="1.9680701"
-       x="-0.48403507"
+       height="2.2113769"
+       y="-0.60568846"
+       width="2.0300131"
+       x="-0.51500655"
        id="filter5535-2"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5537-4"
-         stdDeviation="5.2543488"
-         inkscape:collect="always" />
+         stdDeviation="5.2543488" />
     </filter>
     <filter
-       height="1.140416"
-       y="-0.070208006"
-       width="1.2166662"
-       x="-0.10833312"
+       height="1.1677718"
+       y="-0.079699566"
+       width="1.2477325"
+       x="-0.1123191"
        id="filter5221-4"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5223-8"
-         stdDeviation="0.8812897"
-         inkscape:collect="always" />
+         stdDeviation="0.8812897" />
     </filter>
     <filter
-       height="1.0771819"
-       y="-0.038590964"
-       width="1.2955548"
-       x="-0.14777733"
+       height="1.1269541"
+       y="-0.052982524"
+       width="1.1648626"
+       x="-0.072275"
        id="filter5047-6"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5049-42"
-         stdDeviation="0.44094492"
-         inkscape:collect="always" />
+         stdDeviation="0.44094492" />
     </filter>
     <filter
-       height="1.0771819"
-       y="-0.038590964"
-       width="1.2955548"
-       x="-0.14777733"
+       height="1.2021495"
+       y="-0.087124538"
+       width="1.2180956"
+       x="-0.09933736"
        id="filter5047-9-26"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
+       style="color-interpolation-filters:sRGB">
       <feGaussianBlur
          id="feGaussianBlur5049-4-5"
-         stdDeviation="0.44094492"
-         inkscape:collect="always" />
+         stdDeviation="0.44094492" />
     </filter>
     <filter
-       inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter9959"
-       x="-0.064455215"
-       width="1.1289104"
-       y="-0.070188953"
-       height="1.1403779">
+       x="-0.21562644"
+       width="1.2912061"
+       y="-0.08231898"
+       height="1.167683">
       <feGaussianBlur
-         inkscape:collect="always"
          stdDeviation="1.153101"
          id="feGaussianBlur9961" />
     </filter>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient10573-4"
        id="linearGradient9987"
        gradientUnits="userSpaceOnUse"
@@ -895,34 +356,6 @@
        x2="392.85153"
        y2="467.72714" />
   </defs>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1680"
-     inkscape:window-height="987"
-     id="namedview8108"
-     showgrid="true"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="true"
-     inkscape:snap-nodes="false"
-     inkscape:zoom="13.906433"
-     inkscape:cx="11.379403"
-     inkscape:cy="26.463725"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg8106"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid8116" />
-  </sodipodi:namedview>
   <g
      transform="matrix(1.0465811,0,0,1.0470542,-0.55416526,0.68776954)"
      id="g9149-6"
@@ -932,14 +365,10 @@
        id="g8880-4"
        style="fill:#808080;stroke:#808080;stroke-width:0.95527625">
       <path
-         sodipodi:nodetypes="csc"
-         inkscape:connector-curvature="0"
          id="path5034-5-9-5"
          d="M 31.844198,8.0138003 C 29.368203,6.7090177 28.181804,5.4491653 28.513581,4.4316487 28.832068,3.4549016 32.489259,3.6806392 33.061426,7.6363088"
          style="fill:#808080;fill-rule:evenodd;stroke:#808080;stroke-width:0.95527637;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         sodipodi:nodetypes="csc"
-         inkscape:connector-curvature="0"
          id="path5034-5-1"
          d="M 35.000833,8.0138003 C 37.476828,6.7090177 38.663227,5.4491653 38.33145,4.4316487 38.012963,3.4549016 34.355772,3.6806392 33.783605,7.6363088"
          style="fill:#808080;fill-rule:evenodd;stroke:#808080;stroke-width:0.95527637;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -962,17 +391,12 @@
     <path
        style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:0.95527625;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        d="M 23.500003,7.499637 V 17.958639 28.499998 H 33.958825 44.499999 V 17.958639 17.876465 7.5000022 H 33.958825 23.500003 Z"
-       id="rect10961-8-3-6-7-4"
-       inkscape:connector-curvature="0" />
+       id="rect10961-8-3-6-7-4" />
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
        id="path11108-6-7-5-8-5"
        d="M 43.999999,18 H 23.132419"
        style="font-style:normal;font-weight:normal;font-size:medium;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:1.91055274;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
        id="path11108-6-7-5-5-5"
        d="M 34,7.0628993 V 27.999999"
        style="font-style:normal;font-weight:normal;font-size:medium;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:1.91055274;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
@@ -988,27 +412,20 @@
          cx="58.422024"
          cy="1080.8622" />
       <path
-         inkscape:connector-curvature="0"
          id="path5381-3-1-9"
          d="m 58.302068,1061.192 a 19.925179,19.996828 0 0 0 -16.566406,8.9061 13.02639,11.919721 0 0 0 -0.08789,1.3262 13.02639,11.919721 0 0 0 13.027344,11.9199 13.02639,11.919721 0 0 0 13.025391,-11.9199 13.02639,11.919721 0 0 0 -5.744141,-9.8788 19.925179,19.996828 0 0 0 -3.654297,-0.3535 z"
          style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:1.61378765;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5535-3-5)" />
       <path
-         sodipodi:nodetypes="ccc"
-         inkscape:connector-curvature="0"
          id="path4955-0-2"
          d="m 56.918293,1098.9541 c 13.138983,1.3446 26.215947,-13.2506 15.6794,-30.04 4.270131,11.66 -2.596726,28.1272 -15.6794,30.04 z"
          style="display:inline;fill:#808080;fill-opacity:1;fill-rule:evenodd;stroke:#808080;stroke-width:1.07585847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5221-5-8)" />
       <path
          transform="rotate(139.69065,43.086899,1066.2857)"
-         sodipodi:nodetypes="ccc"
-         inkscape:connector-curvature="0"
          id="path4955-4-4-4"
          d="m 42.016424,1063.8653 c 10.35108,-1.0571 18.719697,-7.243 16.998227,-21.5409 -1.492,9.5512 -7.513167,18.0332 -16.998227,21.5409 z"
          style="display:inline;fill:#808080;fill-opacity:1;fill-rule:evenodd;stroke:#808080;stroke-width:1.07585847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5047-7-2)" />
       <path
          transform="rotate(-143.53505,55.910344,1060.001)"
-         sodipodi:nodetypes="ccc"
-         inkscape:connector-curvature="0"
          id="path4955-4-7-3-5"
          d="m 45.362135,1063.2149 c 4.386725,-0.8085 13.867651,-6.3281 13.426551,-13.7995 -1.860415,6.6958 -7.631082,10.3187 -13.426551,13.7995 z"
          style="display:inline;fill:#808080;fill-opacity:1;fill-rule:evenodd;stroke:#808080;stroke-width:1.07585847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5047-9-2-9)" />
@@ -1032,27 +449,20 @@
          cx="102.42202"
          cy="1022.8622" />
       <path
-         inkscape:connector-curvature="0"
          id="path5381-3-5"
          d="m 102.30207,1003.192 a 19.925179,19.996828 0 0 0 -16.566408,8.9061 13.02639,11.919721 0 0 0 -0.08789,1.3262 13.02639,11.919721 0 0 0 13.027344,11.9199 13.02639,11.919721 0 0 0 13.025394,-11.9199 13.02639,11.919721 0 0 0 -5.74414,-9.8788 19.925179,19.996828 0 0 0 -3.6543,-0.3535 z"
          style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:1.61378765;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5535-2)" />
       <path
-         sodipodi:nodetypes="ccc"
-         inkscape:connector-curvature="0"
          id="path4955-7"
          d="m 100.91829,1040.9541 c 13.13899,1.3446 26.21595,-13.2506 15.6794,-30.04 4.27013,11.66 -2.59672,28.1272 -15.6794,30.04 z"
          style="display:inline;fill:#808080;fill-opacity:1;fill-rule:evenodd;stroke:#808080;stroke-width:1.07585847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5221-4)" />
       <path
          transform="rotate(139.69065,75.730782,1045.3603)"
-         sodipodi:nodetypes="ccc"
-         inkscape:connector-curvature="0"
          id="path4955-4-1"
          d="m 42.016424,1063.8653 c 10.35108,-1.0571 18.719697,-7.243 16.998227,-21.5409 -1.492,9.5512 -7.513167,18.0332 -16.998227,21.5409 z"
          style="display:inline;fill:#808080;fill-opacity:1;fill-rule:evenodd;stroke:#808080;stroke-width:1.07585847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5047-6)" />
       <path
          transform="rotate(-143.53505,68.357411,1023.7539)"
-         sodipodi:nodetypes="ccc"
-         inkscape:connector-curvature="0"
          id="path4955-4-7-6"
          d="m 45.362135,1063.2149 c 4.386725,-0.8085 13.867651,-6.3281 13.426551,-13.7995 -1.860415,6.6958 -7.631082,10.3187 -13.426551,13.7995 z"
          style="display:inline;fill:#808080;fill-opacity:1;fill-rule:evenodd;stroke:#808080;stroke-width:1.07585847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5047-9-26)" />
@@ -1103,15 +513,11 @@
     <path
        style="fill:none;fill-rule:evenodd;stroke:#794f40;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 31.844198,8.0138003 C 29.368203,6.7090177 28.181804,5.4491653 28.513581,4.4316487 28.832068,3.4549016 32.489259,3.6806392 33.061426,7.6363088"
-       id="path5034-5-9"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csc" />
+       id="path5034-5-9" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#794f40;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 35.000833,8.0138003 C 37.476828,6.7090177 38.663227,5.4491653 38.33145,4.4316487 38.012963,3.4549016 34.355772,3.6806392 33.783605,7.6363088"
-       id="path5034-5"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csc" />
+       id="path5034-5" />
   </g>
   <rect
      y="7.9538245"
@@ -1129,22 +535,17 @@
      id="path5111-7"
      style="opacity:0.81300001;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.68641603;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5309-8)" />
   <path
-     inkscape:connector-curvature="0"
      id="rect10961-8-3-6-7"
      d="M 23.500003,7.499637 V 17.958639 28.499998 H 33.958825 44.499999 V 17.958639 17.876465 7.5000022 H 33.958825 23.500003 Z"
      style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;fill-opacity:1;stroke:url(#linearGradient9987);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
      style="font-style:normal;font-weight:normal;font-size:medium;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#915323;fill-opacity:1;stroke:url(#linearGradient4895-6);stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 43.999999,18 H 23.132419"
-     id="path11108-6-7-5-8"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cc" />
+     id="path11108-6-7-5-8" />
   <path
      style="font-style:normal;font-weight:normal;font-size:medium;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#915323;fill-opacity:1;stroke:url(#linearGradient4895-8);stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 34,7.0628993 V 27.999999"
-     id="path11108-6-7-5-5"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cc" />
+     id="path11108-6-7-5-5" />
   <ellipse
      ry="12.696641"
      rx="12.597186"
@@ -1153,23 +554,17 @@
      cx="14.161288"
      cy="24.495987" />
   <path
-     sodipodi:nodetypes="ccc"
-     inkscape:connector-curvature="0"
      id="path4955-0"
      d="m 56.918293,1098.9541 c 13.138983,1.3446 26.215947,-13.2506 15.6794,-30.04 4.270131,11.66 -2.596726,28.1272 -15.6794,30.04 z"
      style="display:inline;fill:#7d669c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12622762px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5221-5)"
      transform="matrix(0.63222452,0,0,0.63493274,-22.774548,-661.7788)" />
   <path
      transform="matrix(-0.48211088,0.41074702,-0.40899504,-0.48417607,461.34427,513.8131)"
-     sodipodi:nodetypes="ccc"
-     inkscape:connector-curvature="0"
      id="path4955-4-4"
      d="m 42.016424,1063.8653 c 10.35108,-1.0571 18.719697,-7.243 16.998227,-21.5409 -1.492,9.5512 -7.513167,18.0332 -16.998227,21.5409 z"
      style="display:inline;fill:#e7e2f2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12622762px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5047-7)" />
   <path
      transform="matrix(-0.50844797,-0.37736016,0.37575058,-0.51062598,-357.29515,573.61293)"
-     sodipodi:nodetypes="ccc"
-     inkscape:connector-curvature="0"
      id="path4955-4-7-3"
      d="m 45.362135,1063.2149 c 4.386725,-0.8085 13.867651,-6.3281 13.426551,-13.7995 -1.860415,6.6958 -7.631082,10.3187 -13.426551,13.7995 z"
      style="display:inline;fill:#dfd3e9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12622762px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5047-9-2)" />
@@ -1188,29 +583,22 @@
      cx="21.669151"
      cy="31.142838" />
   <path
-     inkscape:connector-curvature="0"
      id="path5381-3"
      d="m 102.30207,1003.192 a 19.925179,19.996828 0 0 0 -16.566408,8.9061 13.02639,11.919721 0 0 0 -0.08789,1.3262 13.02639,11.919721 0 0 0 13.027344,11.9199 13.02639,11.919721 0 0 0 13.025394,-11.9199 13.02639,11.919721 0 0 0 -5.74414,-9.8788 19.925179,19.996828 0 0 0 -3.6543,-0.3535 z"
      style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.68934131;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5535)"
      transform="matrix(0.60902244,0,0,0.61163793,-40.708157,-594.47847)" />
   <path
-     sodipodi:nodetypes="ccc"
-     inkscape:connector-curvature="0"
      id="path4955"
      d="m 100.91829,1040.9541 c 13.13899,1.3446 26.21595,-13.2506 15.6794,-30.04 4.27013,11.66 -2.59672,28.1272 -15.6794,30.04 z"
      style="display:inline;fill:#2b630c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12622762px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5221)"
      transform="matrix(0.60902244,0,0,0.61163793,-40.708157,-594.47847)" />
   <path
      transform="matrix(-0.46441784,0.39567728,-0.39398528,-0.46641231,452.44089,502.50751)"
-     sodipodi:nodetypes="ccc"
-     inkscape:connector-curvature="0"
      id="path4955-4"
      d="m 42.016424,1063.8653 c 10.35108,-1.0571 18.719697,-7.243 16.998227,-21.5409 -1.492,9.5512 -7.513167,18.0332 -16.998227,21.5409 z"
      style="display:inline;fill:#9bed38;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12622762px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5047)" />
   <path
      transform="matrix(-0.48978838,-0.36351534,0.36196087,-0.49189181,-336.15515,560.11338)"
-     sodipodi:nodetypes="ccc"
-     inkscape:connector-curvature="0"
      id="path4955-4-7"
      d="m 45.362135,1063.2149 c 4.386725,-0.8085 13.867651,-6.3281 13.426551,-13.7995 -1.860415,6.6958 -7.631082,10.3187 -13.426551,13.7995 z"
      style="display:inline;fill:#bcee73;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12622762px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter5047-9)" />

--- a/org.eclipse.jdt/images/topiclabel/sa_samplepyramid48.svg
+++ b/org.eclipse.jdt/images/topiclabel/sa_samplepyramid48.svg
@@ -2,21 +2,17 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    id="svg815"
    width="48"
    height="48"
    viewBox="0 0 48 48"
-   sodipodi:docname="sa_samplepyramid48.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata821">
     <rdf:RDF>
@@ -25,14 +21,13 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs819">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient873">
       <stop
          style="stop-color:#86cb2a;stop-opacity:1;"
@@ -44,7 +39,6 @@
          id="stop871" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient865">
       <stop
          style="stop-color:#86cb2a;stop-opacity:1"
@@ -56,7 +50,6 @@
          id="stop863" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient857">
       <stop
          style="stop-color:#76c211;stop-opacity:1"
@@ -68,7 +61,6 @@
          id="stop855" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient841">
       <stop
          style="stop-color:#86cb2a;stop-opacity:1"
@@ -80,7 +72,6 @@
          id="stop839" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient841"
        id="linearGradient843"
        x1="22.754219"
@@ -89,7 +80,6 @@
        y2="43.041695"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient857"
        id="linearGradient859"
        x1="5.7554464"
@@ -98,7 +88,6 @@
        y2="20.813345"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient865"
        id="linearGradient867"
        x1="22.500338"
@@ -107,7 +96,6 @@
        y2="13.237538"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient873"
        id="linearGradient875"
        x1="25.184374"
@@ -116,7 +104,6 @@
        y2="38.356731"
        gradientUnits="userSpaceOnUse" />
     <filter
-       inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter937"
        x="-0.25475353"
@@ -124,91 +111,53 @@
        y="-0.053771651"
        height="1.1075433">
       <feGaussianBlur
-         inkscape:collect="always"
          stdDeviation="0.70925815"
          id="feGaussianBlur939" />
     </filter>
     <filter
-       inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter937-0"
-       x="-0.25475353"
-       width="1.5095071"
-       y="-0.053771652"
-       height="1.1075433">
+       x="-0.32176651"
+       width="1.6435368"
+       y="-0.067914168"
+       height="1.1358197">
       <feGaussianBlur
-         inkscape:collect="always"
          stdDeviation="0.70925815"
          id="feGaussianBlur939-3" />
     </filter>
     <filter
-       inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter1048"
-       x="-0.064151847"
-       width="1.1283037"
-       y="-0.065461384"
-       height="1.1309228">
+       x="-0.07624906"
+       width="1.1524767"
+       y="-0.077784966"
+       height="1.1555914">
       <feGaussianBlur
-         inkscape:collect="always"
          stdDeviation="0.98934756"
          id="feGaussianBlur1050" />
     </filter>
   </defs>
-  <sodipodi:namedview
-     pagecolor="#d4d4d4"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1017"
-     id="namedview817"
-     showgrid="true"
-     inkscape:snap-global="false"
-     inkscape:zoom="6.3713267"
-     inkscape:cx="22.628886"
-     inkscape:cy="32.726247"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg815">
-    <inkscape:grid
-       type="xygrid"
-       id="grid825" />
-  </sodipodi:namedview>
   <g
      transform="matrix(1.1182073,0,0,1.1184737,-2.7703917,-1.1833704)"
      id="g946-6"
      style="opacity:0.51999996;fill:#999999;fill-opacity:1;stroke:#999999;stroke-width:0.89418209;stroke-opacity:1;filter:url(#filter1048)">
     <path
-       inkscape:connector-curvature="0"
        id="path827-8"
        d="M 5.4381503,27.745665 29.465896,41.285549 42.339884,24.63815 22.52948,17.53526 Z"
        style="fill:#999999;fill-opacity:1;stroke:#999999;stroke-width:0.89559019;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       inkscape:connector-curvature="0"
        id="path845-8"
        d="M 5.4381506,27.48725 22.363006,5.0132612 22.52948,17.165863 Z"
        style="fill:#999999;fill-opacity:1;stroke:#999999;stroke-width:0.89418209px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
        id="path847-2"
        d="M 22.52948,17.53526 42.450867,24.582659 22.529479,5.1884393 Z"
        style="fill:#999999;fill-opacity:1;stroke:#999999;stroke-width:0.89418209px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
        id="path851-8"
        d="M 29.835294,39.245157 30.757856,14.537655 24.076027,7.5887077 Z"
        style="opacity:0.5979996;fill:#999999;fill-opacity:1;stroke:#999999;stroke-width:0.89559019;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter937-0)" />
     <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
        id="path849-7"
        d="M 5.5491329,27.717919 29.493641,41.257803 22.584971,5.0774567 Z"
        style="fill:#999999;fill-opacity:1;stroke:#999999;stroke-width:0.89418209px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
@@ -216,30 +165,22 @@
   <g
      id="g946">
     <path
-       inkscape:connector-curvature="0"
        id="path827"
        d="M 5.4381503,27.745665 29.465896,41.285549 42.339884,24.63815 22.52948,17.53526 Z"
        style="fill:url(#linearGradient875);stroke:url(#linearGradient843);stroke-width:1.0015748;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1" />
     <path
-       inkscape:connector-curvature="0"
        id="path845"
        d="M 5.4381506,27.48725 22.363006,5.0132612 22.52948,17.165863 Z"
        style="fill:#93de3f;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
        id="path847"
        d="M 22.52948,17.53526 42.450867,24.582659 22.529479,5.1884393 Z"
        style="fill:#93de3f;stroke:url(#linearGradient867);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1" />
     <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
        id="path851"
        d="M 29.835294,39.245157 30.757856,14.537655 24.076027,7.5887077 Z"
        style="opacity:0.59799972;fill:#ffffff;stroke:none;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter937)" />
     <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
        id="path849"
        d="M 5.5491329,27.717919 29.493641,41.257803 22.584971,5.0774567 Z"
        style="fill:none;stroke:url(#linearGradient859);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />

--- a/org.eclipse.jdt/images/topiclabel/tu_javaapp48.svg
+++ b/org.eclipse.jdt/images/topiclabel/tu_javaapp48.svg
@@ -2,21 +2,17 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    id="svg10017"
    width="48"
    height="48"
    viewBox="0 0 48 48"
-   sodipodi:docname="tu_javaapp48.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata10023">
     <rdf:RDF>
@@ -25,14 +21,13 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs10021">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5904">
       <stop
          style="stop-color:#c5c6c6;stop-opacity:1"
@@ -44,7 +39,6 @@
          id="stop5908" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5898">
       <stop
          style="stop-color:#c0c1c1;stop-opacity:1"
@@ -56,8 +50,7 @@
          id="stop5902" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4581"
-       inkscape:collect="always">
+       id="linearGradient4581">
       <stop
          id="stop4583"
          offset="0"
@@ -68,8 +61,7 @@
          style="stop-color:#9f9f9f;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4541"
-       inkscape:collect="always">
+       id="linearGradient4541">
       <stop
          id="stop4543"
          offset="0"
@@ -80,8 +72,7 @@
          style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4461"
-       inkscape:collect="always">
+       id="linearGradient4461">
       <stop
          id="stop4463"
          offset="0"
@@ -100,422 +91,6 @@
          style="stop-color:#b4b4b4;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4972"
-       inkscape:collect="always">
-      <stop
-         id="stop4974"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop4976"
-         offset="1"
-         style="stop-color:#f5f8fd;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4964"
-       inkscape:collect="always">
-      <stop
-         id="stop4966"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop4968"
-         offset="1"
-         style="stop-color:#e8eefa;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4956"
-       inkscape:collect="always">
-      <stop
-         id="stop4958"
-         offset="0"
-         style="stop-color:#fcfdfe;stop-opacity:1" />
-      <stop
-         id="stop4960"
-         offset="1"
-         style="stop-color:#dee6f8;stop-opacity:1" />
-    </linearGradient>
-    <filter
-       id="filter8854"
-       inkscape:label="Drop Shadow"
-       style="color-interpolation-filters:sRGB">
-      <feFlood
-         id="feFlood8856"
-         result="flood"
-         flood-color="rgb(244,248,254)"
-         flood-opacity="0.933333" />
-      <feComposite
-         id="feComposite8858"
-         result="composite1"
-         operator="in"
-         in2="SourceGraphic"
-         in="flood" />
-      <feGaussianBlur
-         id="feGaussianBlur8860"
-         result="blur"
-         stdDeviation="1.2"
-         in="composite1" />
-      <feOffset
-         id="feOffset8862"
-         result="offset"
-         dy="3"
-         dx="-1" />
-      <feComposite
-         id="feComposite8864"
-         result="composite2"
-         operator="over"
-         in2="offset"
-         in="SourceGraphic" />
-    </filter>
-    <linearGradient
-       id="linearGradient6122">
-      <stop
-         id="stop6124"
-         offset="0"
-         style="stop-color:#c0c0c0;stop-opacity:1" />
-      <stop
-         style="stop-color:#adadad;stop-opacity:1"
-         offset="0.5"
-         id="stop6132" />
-      <stop
-         id="stop6126"
-         offset="1"
-         style="stop-color:#808080;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7087">
-      <stop
-         id="stop7089"
-         offset="0"
-         style="stop-color:#17325d;stop-opacity:1;" />
-      <stop
-         style="stop-color:#b4d0e2;stop-opacity:1"
-         offset="0.25"
-         id="stop7091" />
-      <stop
-         style="stop-color:#b7d2e4;stop-opacity:1"
-         offset="0.5"
-         id="stop7093" />
-      <stop
-         id="stop7095"
-         offset="0.75"
-         style="stop-color:#acc9de;stop-opacity:1" />
-      <stop
-         id="stop7097"
-         offset="1"
-         style="stop-color:#3e72a7;stop-opacity:1" />
-    </linearGradient>
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask7366">
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path7368"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-    </mask>
-    <linearGradient
-       id="linearGradient7584-5">
-      <stop
-         style="stop-color:#f9cd5f;stop-opacity:1"
-         offset="0"
-         id="stop7586-4" />
-      <stop
-         style="stop-color:#fbf0b4;stop-opacity:1"
-         offset="1"
-         id="stop7588-5" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7592-1">
-      <stop
-         style="stop-color:#bd8416;stop-opacity:1"
-         offset="0"
-         id="stop7594-6" />
-      <stop
-         style="stop-color:#a66b10;stop-opacity:1"
-         offset="1"
-         id="stop7596-9" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
-      <stop
-         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1"
-         offset="0"
-         style="stop-color:#5aad60;stop-opacity:1;" />
-      <stop
-         style="stop-color:#5bb26a;stop-opacity:1;"
-         offset="0.5"
-         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9" />
-      <stop
-         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0"
-         offset="1"
-         style="stop-color:#a4c589;stop-opacity:1" />
-    </linearGradient>
-    <mask
-       id="mask7366-4"
-       maskUnits="userSpaceOnUse">
-      <path
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         id="path7368-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccc" />
-    </mask>
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-20,0)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9331"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9333"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-18,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9335"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-16,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9337"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-14,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9339"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-12,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4956"
-       id="linearGradient68073"
-       x1="88.220117"
-       y1="1042.7973"
-       x2="163.22012"
-       y2="1042.7973"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4964"
-       id="linearGradient68075"
-       x1="94.469681"
-       y1="1032.2668"
-       x2="163.22012"
-       y2="1032.2669"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4972"
-       id="linearGradient68077"
-       x1="88.220116"
-       y1="1032.2668"
-       x2="152.72206"
-       y2="1032.2668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <filter
-       style="color-interpolation-filters:sRGB"
-       inkscape:label="Drop Shadow"
-       id="filter8854-9">
-      <feFlood
-         flood-opacity="0.933333"
-         flood-color="rgb(244,248,254)"
-         result="flood"
-         id="feFlood8856-0" />
-      <feComposite
-         in="flood"
-         in2="SourceGraphic"
-         operator="in"
-         result="composite1"
-         id="feComposite8858-2" />
-      <feGaussianBlur
-         in="composite1"
-         stdDeviation="1.2"
-         result="blur"
-         id="feGaussianBlur8860-3" />
-      <feOffset
-         dx="-1"
-         dy="3"
-         result="offset"
-         id="feOffset8862-2" />
-      <feComposite
-         in="SourceGraphic"
-         in2="offset"
-         operator="over"
-         result="composite2"
-         id="feComposite8864-3" />
-    </filter>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
-      <stop
-         style="stop-color:#7564b1;stop-opacity:1"
-         offset="0"
-         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
-      <stop
-         id="stop10806-6-8-5-3-9-24-8-4-3-2"
-         offset="0.5"
-         style="stop-color:#5d4aa1;stop-opacity:1" />
-      <stop
-         style="stop-color:#9283c3;stop-opacity:1"
-         offset="1"
-         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7540-2-3-8-7">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop7542-8-7-5-3" />
-      <stop
-         id="stop7544-8-2-0-5"
-         offset="0.47623286"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop7546-1-7-9-5"
-         offset="0.5"
-         style="stop-color:#ffffff;stop-opacity:0" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop7548-98-9-2-4" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7272-66-4-5-5-5-8"
-       inkscape:collect="always">
-      <stop
-         id="stop7274-6-0-1-7-4-7"
-         offset="0"
-         style="stop-color:#8f6c10;stop-opacity:1" />
-      <stop
-         id="stop7276-66-6-3-9-1-4"
-         offset="1"
-         style="stop-color:#c9a645;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       id="linearGradient10540"
-       gradientUnits="userSpaceOnUse"
-       x1="-22.453552"
-       y1="1030.3411"
-       x2="-10.159802"
-       y2="1030.3411" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       id="linearGradient10542"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
-       x1="-22.453552"
-       y1="1030.3411"
-       x2="-10.159802"
-       y2="1030.3411" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7272-66-4-5-5-5-8"
-       id="linearGradient10544"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
-       x1="-15.945988"
-       y1="1037.4661"
-       x2="-15.945988"
-       y2="1023.2569" />
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask10620">
-      <path
-         sodipodi:type="arc"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
-         id="path10622"
-         sodipodi:cx="388.125"
-         sodipodi:cy="468.23718"
-         sodipodi:rx="10.625"
-         sodipodi:ry="10.625"
-         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
-         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)" />
-    </mask>
-    <linearGradient
-       id="linearGradient4528-9-5-7-9-7-3">
-      <stop
-         style="stop-color:#e0c576;stop-opacity:1;"
-         offset="0"
-         id="stop4530-0-5-0-5-8-4" />
-      <stop
-         style="stop-color:#9e7916;stop-opacity:1"
-         offset="1"
-         id="stop4532-7-9-3-3-6-1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
-      <stop
-         id="stop6283-0-2-2-1-2-0-1-6-0"
-         offset="0"
-         style="stop-color:#f7f9fb;stop-opacity:1" />
-      <stop
-         id="stop6285-5-0-9-7-6-9-9-1-9"
-         offset="1"
-         style="stop-color:#ffd680;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3827">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="0"
-         id="stop3829" />
-      <stop
-         id="stop3835"
-         offset="0.60149658"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop3831" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
-      <stop
-         style="stop-color:#f3faed;stop-opacity:1"
-         offset="0"
-         id="stop10800-5-2-1-8-20-6-4-9-8-2-9" />
-      <stop
-         id="stop10806-6-8-5-3-9-24-8-4-3-2-4"
-         offset="0.65917557"
-         style="stop-color:#e7f4da;stop-opacity:1" />
-      <stop
-         style="stop-color:#67bf1f;stop-opacity:1"
-         offset="1"
-         id="stop10802-1-5-3-0-4-8-4-2-9-2-5" />
-    </linearGradient>
-    <linearGradient
        gradientTransform="matrix(1.1566974,0,0,0.64381763,-17.108615,-636.15058)"
        gradientUnits="userSpaceOnUse"
        y2="1011.338"
@@ -523,10 +98,8 @@
        y1="1052.4476"
        x1="50.702839"
        id="linearGradient6375-6"
-       xlink:href="#linearGradient4994"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4994" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4994">
       <stop
          style="stop-color:#ffffff;stop-opacity:1"
@@ -545,10 +118,8 @@
        gradientTransform="matrix(4.0867057,0,0,3.0380179,-18.965761,-3152.7049)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4238"
-       xlink:href="#linearGradient4902"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4902" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4902">
       <stop
          style="stop-color:#777777;stop-opacity:0.74901962"
@@ -571,8 +142,7 @@
        y1="1001.3622"
        x1="60.069771"
        id="linearGradient4467"
-       xlink:href="#linearGradient4461"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4461" />
     <linearGradient
        gradientTransform="matrix(1.2844562,0,0,1.2516553,-48.662706,-1246.996)"
        gradientUnits="userSpaceOnUse"
@@ -581,8 +151,7 @@
        y1="1007.8622"
        x1="41"
        id="linearGradient4547"
-       xlink:href="#linearGradient4541"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4541" />
     <linearGradient
        gradientTransform="matrix(0,1.2221273,-1.2541542,0,1268.4913,-35.107142)"
        gradientUnits="userSpaceOnUse"
@@ -591,8 +160,7 @@
        y1="1007.8622"
        x1="41"
        id="linearGradient4547-0"
-       xlink:href="#linearGradient4541"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4541" />
     <radialGradient
        gradientTransform="translate(-37.999995,-993.36223)"
        gradientUnits="userSpaceOnUse"
@@ -602,8 +170,7 @@
        cy="1004.8622"
        cx="68.5"
        id="radialGradient4587"
-       xlink:href="#linearGradient4581"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4581" />
     <radialGradient
        gradientUnits="userSpaceOnUse"
        r="1.5"
@@ -613,7 +180,6 @@
        cx="68.5"
        id="radialGradient4587-5"
        xlink:href="#linearGradient4581"
-       inkscape:collect="always"
        gradientTransform="translate(-32.999995,-993.36223)" />
     <radialGradient
        gradientUnits="userSpaceOnUse"
@@ -624,18 +190,7 @@
        cx="68.5"
        id="radialGradient4587-0"
        xlink:href="#linearGradient4581"
-       inkscape:collect="always"
        gradientTransform="translate(-28.000016,-993.36223)" />
-    <linearGradient
-       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)"
-       gradientUnits="userSpaceOnUse"
-       y2="1008.3622"
-       x2="60"
-       y1="1007.8622"
-       x1="41"
-       id="linearGradient5885"
-       xlink:href="#linearGradient4541"
-       inkscape:collect="always" />
     <linearGradient
        y2="1007.8358"
        x2="60.03624"
@@ -644,8 +199,7 @@
        gradientTransform="matrix(-2.055096,0,0,-1.2274096,128.27082,1278.6095)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient5890"
-       xlink:href="#linearGradient5904"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient5904" />
     <linearGradient
        y2="1007.8496"
        x2="59.944244"
@@ -654,8 +208,7 @@
        gradientTransform="matrix(0,-1.3017002,2.1794835,0,-2153.0952,94.443886)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient5892"
-       xlink:href="#linearGradient5898"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient5898" />
     <linearGradient
        gradientUnits="userSpaceOnUse"
        y2="1285.8445"
@@ -663,11 +216,9 @@
        y1="1285.8445"
        x1="27.360373"
        id="linearGradient4585"
-       xlink:href="#linearGradient4548"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4548" />
     <linearGradient
-       id="linearGradient4548"
-       inkscape:collect="always">
+       id="linearGradient4548">
       <stop
          id="stop4550"
          offset="0"
@@ -684,11 +235,9 @@
        y1="1285.8445"
        x1="27.360373"
        id="linearGradient4577"
-       xlink:href="#linearGradient4540"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4540" />
     <linearGradient
-       id="linearGradient4540"
-       inkscape:collect="always">
+       id="linearGradient4540">
       <stop
          id="stop4542"
          offset="0"
@@ -699,7 +248,6 @@
          style="stop-color:#3b70a0;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4548"
        id="linearGradient10760"
        gradientUnits="userSpaceOnUse"
@@ -708,7 +256,6 @@
        x2="37.947941"
        y2="1285.8445" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4540"
        id="linearGradient10762"
        gradientUnits="userSpaceOnUse"
@@ -717,111 +264,62 @@
        x2="37.947941"
        y2="1285.8445" />
     <filter
-       inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter11539"
-       x="-0.05151025"
-       width="1.1030205"
-       y="-0.054155996"
-       height="1.108312">
+       x="-0.063705383"
+       width="1.1274108"
+       y="-0.067055776"
+       height="1.1340333">
       <feGaussianBlur
-         inkscape:collect="always"
          stdDeviation="0.87996598"
          id="feGaussianBlur11541" />
     </filter>
   </defs>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1017"
-     id="namedview10019"
-     showgrid="true"
-     inkscape:snap-nodes="false"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="-0.034940239"
-     inkscape:cy="21.745495"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg10017">
-    <inkscape:grid
-       type="xygrid"
-       id="grid10820" />
-  </sodipodi:namedview>
   <path
      style="opacity:0.50700001;fill:#808080;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter11539)"
      d="m 5.1119183,6.1119183 c 17.8978207,0.108917 40.9999627,0 40.9999627,0 V 45.108862 H 5.1119183 Z"
-     id="rect4001-1-0"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-1-0" />
   <path
      style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none;stroke-width:1"
      d="m 3.9884989,14 40.0229971,2.9e-4 c 0,0 -0.06553,14.85449 0,28.02424 H 3.9884989 Z"
-     id="rect4001-3-4"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4" />
   <path
      style="fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
      d="m 3.5000182,3.5030177 c 17.8978208,0.1089172 40.9999628,0 40.9999628,0 V 42.499962 H 3.5000182 Z"
-     id="rect4001-1"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-1" />
   <path
      style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
      d="m 3.9884989,8.731046 40.0229971,9.51e-5 c 0,0 -0.06553,3.0252359 0,5.7073599 H 3.9884989 Z"
-     id="rect4001-3-4-1"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1" />
   <path
      style="display:inline;fill:url(#linearGradient4467);fill-opacity:1;stroke:none;stroke-width:1"
      d="m 3.9884989,3.9748339 40.0229971,8.37e-5 c 0,0 -0.0655,2.6635894 0,5.0250824 H 3.9884989 Z"
-     id="rect4001-3-4-1-6"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1-6" />
   <path
      style="display:inline;fill:url(#radialGradient4587);fill-opacity:1;stroke:none;stroke-width:1"
      d="m 28.999999,9.9999997 3,1.003e-4 c 0,0 -0.005,1.5901 0,2.9999 h -3 z"
-     id="rect4001-3-4-1-1-8"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1-1-8" />
   <path
-     inkscape:connector-curvature="0"
      id="path4539"
      d="M 4,14.5 H 28.404667"
      style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     inkscape:connector-curvature="0"
      id="path4539-4"
      d="M 4.4765851,15 V 38.220416"
      style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-0);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
      style="display:inline;fill:url(#radialGradient4587-5);fill-opacity:1;stroke:none;stroke-width:1"
      d="m 33.999999,9.9999997 3,1.003e-4 c 0,0 -0.005,1.5901 0,2.9999 h -3 z"
-     id="rect4001-3-4-1-1-8-5"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1-1-8-5" />
   <path
      style="display:inline;fill:url(#radialGradient4587-0);fill-opacity:1;stroke:none;stroke-width:1"
      d="M 38.999999,9.9999997 42,10.0001 c 0,0 -0.005,1.5901 0,2.9999 h -3.000001 z"
-     id="rect4001-3-4-1-1-8-3"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1-1-8-3" />
   <path
-     inkscape:connector-curvature="0"
      id="path4539-6"
      d="M 44.011897,41.549766 H 4.9650707"
      style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient5890);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     inkscape:connector-curvature="0"
      id="path4539-4-6"
      d="M 43.523813,41.07424 V 16.341841"
      style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5892);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
@@ -830,15 +328,12 @@
      style="font-style:normal;font-weight:normal;font-size:41.01252365px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4585);fill-opacity:1;stroke:url(#linearGradient4577);stroke-width:1.15016568px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      transform="matrix(0.99705397,0,0,0.75815946,-7.9110079,-947.43404)">
     <path
-       sodipodi:nodetypes="cccccczccscccssccsc"
-       inkscape:connector-curvature="0"
        id="path4569"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Calibri;fill:url(#linearGradient10760);fill-opacity:1;stroke:url(#linearGradient10762);stroke-width:1.15016568px;stroke-opacity:1"
        d="m 37.447942,1292.1524 c 0,1.028 -0.09345,1.9692 -0.280359,2.8236 -0.186906,0.8545 -0.507316,1.5821 -0.961231,2.1828 -1.564625,1.8279 -3.608742,1.8405 -5.718918,1.8497 -1.204301,-0.01 -2.301584,-0.2915 -3.384334,-0.9412 -0.313493,-0.2299 -0.331037,-0.6499 -0.323274,-0.9416 0.02582,-1.4687 -0.0081,-3.3729 0,-4.4553 0.0081,-1.0824 2.165091,0.2177 3.230931,0.02 1.830381,-0.2352 2.534326,-2.0006 2.614942,-3.9924 l 0.03533,-15.4294 c 2.14e-4,-0.093 0.0267,-0.1802 0.0801,-0.2603 0.0534,-0.08 0.146853,-0.1468 0.280359,-0.2002 0.133504,-0.053 0.30706,-0.093 0.520666,-0.1202 0.226958,-0.027 0.507317,-0.04 0.841078,-0.04 0.32041,0 1.936593,0.013 2.16355,0.04 0.226957,0.027 0.400513,0.067 0.520667,0.1202 0.133504,0.053 0.226957,0.1201 0.280359,0.2002 0.06675,0.08 0.100128,0.1669 0.100128,0.2603 z" />
   </g>
   <g
      id="layer3"
-     inkscape:label="old"
      transform="translate(-93.974577,-19.169492)" />
   <g
      id="g11331-3-1-1"

--- a/org.eclipse.jdt/images/topiclabel/tu_swtapp48.svg
+++ b/org.eclipse.jdt/images/topiclabel/tu_swtapp48.svg
@@ -2,21 +2,17 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    id="svg10017"
    width="48"
    height="48"
    viewBox="0 0 48 48"
-   sodipodi:docname="tu_swtapp48.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata10023">
     <rdf:RDF>
@@ -25,14 +21,13 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs10021">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5904">
       <stop
          style="stop-color:#c5c6c6;stop-opacity:1"
@@ -44,7 +39,6 @@
          id="stop5908" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5898">
       <stop
          style="stop-color:#c0c1c1;stop-opacity:1"
@@ -56,8 +50,7 @@
          id="stop5902" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4581"
-       inkscape:collect="always">
+       id="linearGradient4581">
       <stop
          id="stop4583"
          offset="0"
@@ -68,8 +61,7 @@
          style="stop-color:#9f9f9f;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4541"
-       inkscape:collect="always">
+       id="linearGradient4541">
       <stop
          id="stop4543"
          offset="0"
@@ -80,8 +72,7 @@
          style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4461"
-       inkscape:collect="always">
+       id="linearGradient4461">
       <stop
          id="stop4463"
          offset="0"
@@ -100,422 +91,6 @@
          style="stop-color:#b4b4b4;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4972"
-       inkscape:collect="always">
-      <stop
-         id="stop4974"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop4976"
-         offset="1"
-         style="stop-color:#f5f8fd;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4964"
-       inkscape:collect="always">
-      <stop
-         id="stop4966"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop4968"
-         offset="1"
-         style="stop-color:#e8eefa;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4956"
-       inkscape:collect="always">
-      <stop
-         id="stop4958"
-         offset="0"
-         style="stop-color:#fcfdfe;stop-opacity:1" />
-      <stop
-         id="stop4960"
-         offset="1"
-         style="stop-color:#dee6f8;stop-opacity:1" />
-    </linearGradient>
-    <filter
-       id="filter8854"
-       inkscape:label="Drop Shadow"
-       style="color-interpolation-filters:sRGB">
-      <feFlood
-         id="feFlood8856"
-         result="flood"
-         flood-color="rgb(244,248,254)"
-         flood-opacity="0.933333" />
-      <feComposite
-         id="feComposite8858"
-         result="composite1"
-         operator="in"
-         in2="SourceGraphic"
-         in="flood" />
-      <feGaussianBlur
-         id="feGaussianBlur8860"
-         result="blur"
-         stdDeviation="1.2"
-         in="composite1" />
-      <feOffset
-         id="feOffset8862"
-         result="offset"
-         dy="3"
-         dx="-1" />
-      <feComposite
-         id="feComposite8864"
-         result="composite2"
-         operator="over"
-         in2="offset"
-         in="SourceGraphic" />
-    </filter>
-    <linearGradient
-       id="linearGradient6122">
-      <stop
-         id="stop6124"
-         offset="0"
-         style="stop-color:#c0c0c0;stop-opacity:1" />
-      <stop
-         style="stop-color:#adadad;stop-opacity:1"
-         offset="0.5"
-         id="stop6132" />
-      <stop
-         id="stop6126"
-         offset="1"
-         style="stop-color:#808080;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7087">
-      <stop
-         id="stop7089"
-         offset="0"
-         style="stop-color:#17325d;stop-opacity:1;" />
-      <stop
-         style="stop-color:#b4d0e2;stop-opacity:1"
-         offset="0.25"
-         id="stop7091" />
-      <stop
-         style="stop-color:#b7d2e4;stop-opacity:1"
-         offset="0.5"
-         id="stop7093" />
-      <stop
-         id="stop7095"
-         offset="0.75"
-         style="stop-color:#acc9de;stop-opacity:1" />
-      <stop
-         id="stop7097"
-         offset="1"
-         style="stop-color:#3e72a7;stop-opacity:1" />
-    </linearGradient>
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask7366">
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path7368"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-    </mask>
-    <linearGradient
-       id="linearGradient7584-5">
-      <stop
-         style="stop-color:#f9cd5f;stop-opacity:1"
-         offset="0"
-         id="stop7586-4" />
-      <stop
-         style="stop-color:#fbf0b4;stop-opacity:1"
-         offset="1"
-         id="stop7588-5" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7592-1">
-      <stop
-         style="stop-color:#bd8416;stop-opacity:1"
-         offset="0"
-         id="stop7594-6" />
-      <stop
-         style="stop-color:#a66b10;stop-opacity:1"
-         offset="1"
-         id="stop7596-9" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
-      <stop
-         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1"
-         offset="0"
-         style="stop-color:#5aad60;stop-opacity:1;" />
-      <stop
-         style="stop-color:#5bb26a;stop-opacity:1;"
-         offset="0.5"
-         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9" />
-      <stop
-         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0"
-         offset="1"
-         style="stop-color:#a4c589;stop-opacity:1" />
-    </linearGradient>
-    <mask
-       id="mask7366-4"
-       maskUnits="userSpaceOnUse">
-      <path
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         id="path7368-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccc" />
-    </mask>
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-20,0)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9331"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9333"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-18,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9335"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-16,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9337"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-14,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9339"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-12,4.7e-5)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4956"
-       id="linearGradient68073"
-       x1="88.220117"
-       y1="1042.7973"
-       x2="163.22012"
-       y2="1042.7973"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4964"
-       id="linearGradient68075"
-       x1="94.469681"
-       y1="1032.2668"
-       x2="163.22012"
-       y2="1032.2669"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4972"
-       id="linearGradient68077"
-       x1="88.220116"
-       y1="1032.2668"
-       x2="152.72206"
-       y2="1032.2668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-80,0)" />
-    <filter
-       style="color-interpolation-filters:sRGB"
-       inkscape:label="Drop Shadow"
-       id="filter8854-9">
-      <feFlood
-         flood-opacity="0.933333"
-         flood-color="rgb(244,248,254)"
-         result="flood"
-         id="feFlood8856-0" />
-      <feComposite
-         in="flood"
-         in2="SourceGraphic"
-         operator="in"
-         result="composite1"
-         id="feComposite8858-2" />
-      <feGaussianBlur
-         in="composite1"
-         stdDeviation="1.2"
-         result="blur"
-         id="feGaussianBlur8860-3" />
-      <feOffset
-         dx="-1"
-         dy="3"
-         result="offset"
-         id="feOffset8862-2" />
-      <feComposite
-         in="SourceGraphic"
-         in2="offset"
-         operator="over"
-         result="composite2"
-         id="feComposite8864-3" />
-    </filter>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
-      <stop
-         style="stop-color:#7564b1;stop-opacity:1"
-         offset="0"
-         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
-      <stop
-         id="stop10806-6-8-5-3-9-24-8-4-3-2"
-         offset="0.5"
-         style="stop-color:#5d4aa1;stop-opacity:1" />
-      <stop
-         style="stop-color:#9283c3;stop-opacity:1"
-         offset="1"
-         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7540-2-3-8-7">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop7542-8-7-5-3" />
-      <stop
-         id="stop7544-8-2-0-5"
-         offset="0.47623286"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop7546-1-7-9-5"
-         offset="0.5"
-         style="stop-color:#ffffff;stop-opacity:0" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop7548-98-9-2-4" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7272-66-4-5-5-5-8"
-       inkscape:collect="always">
-      <stop
-         id="stop7274-6-0-1-7-4-7"
-         offset="0"
-         style="stop-color:#8f6c10;stop-opacity:1" />
-      <stop
-         id="stop7276-66-6-3-9-1-4"
-         offset="1"
-         style="stop-color:#c9a645;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       id="linearGradient10540"
-       gradientUnits="userSpaceOnUse"
-       x1="-22.453552"
-       y1="1030.3411"
-       x2="-10.159802"
-       y2="1030.3411" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       id="linearGradient10542"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
-       x1="-22.453552"
-       y1="1030.3411"
-       x2="-10.159802"
-       y2="1030.3411" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7272-66-4-5-5-5-8"
-       id="linearGradient10544"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
-       x1="-15.945988"
-       y1="1037.4661"
-       x2="-15.945988"
-       y2="1023.2569" />
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask10620">
-      <path
-         sodipodi:type="arc"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
-         id="path10622"
-         sodipodi:cx="388.125"
-         sodipodi:cy="468.23718"
-         sodipodi:rx="10.625"
-         sodipodi:ry="10.625"
-         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
-         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)" />
-    </mask>
-    <linearGradient
-       id="linearGradient4528-9-5-7-9-7-3">
-      <stop
-         style="stop-color:#e0c576;stop-opacity:1;"
-         offset="0"
-         id="stop4530-0-5-0-5-8-4" />
-      <stop
-         style="stop-color:#9e7916;stop-opacity:1"
-         offset="1"
-         id="stop4532-7-9-3-3-6-1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
-      <stop
-         id="stop6283-0-2-2-1-2-0-1-6-0"
-         offset="0"
-         style="stop-color:#f7f9fb;stop-opacity:1" />
-      <stop
-         id="stop6285-5-0-9-7-6-9-9-1-9"
-         offset="1"
-         style="stop-color:#ffd680;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3827">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="0"
-         id="stop3829" />
-      <stop
-         id="stop3835"
-         offset="0.60149658"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop3831" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
-      <stop
-         style="stop-color:#f3faed;stop-opacity:1"
-         offset="0"
-         id="stop10800-5-2-1-8-20-6-4-9-8-2-9" />
-      <stop
-         id="stop10806-6-8-5-3-9-24-8-4-3-2-4"
-         offset="0.65917557"
-         style="stop-color:#e7f4da;stop-opacity:1" />
-      <stop
-         style="stop-color:#67bf1f;stop-opacity:1"
-         offset="1"
-         id="stop10802-1-5-3-0-4-8-4-2-9-2-5" />
-    </linearGradient>
-    <linearGradient
        gradientTransform="matrix(1.1566974,0,0,0.64381763,-17.108615,-636.15058)"
        gradientUnits="userSpaceOnUse"
        y2="1011.338"
@@ -523,10 +98,8 @@
        y1="1052.4476"
        x1="50.702839"
        id="linearGradient6375-6"
-       xlink:href="#linearGradient4994"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4994" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4994">
       <stop
          style="stop-color:#ffffff;stop-opacity:1"
@@ -545,10 +118,8 @@
        gradientTransform="matrix(4.0867057,0,0,3.0380179,-18.965761,-3152.7049)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient4238"
-       xlink:href="#linearGradient4902"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4902" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4902">
       <stop
          style="stop-color:#777777;stop-opacity:0.74901962"
@@ -571,8 +142,7 @@
        y1="1001.3622"
        x1="60.069771"
        id="linearGradient4467"
-       xlink:href="#linearGradient4461"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4461" />
     <linearGradient
        gradientTransform="matrix(1.2844562,0,0,1.2516553,-48.662706,-1246.996)"
        gradientUnits="userSpaceOnUse"
@@ -581,8 +151,7 @@
        y1="1007.8622"
        x1="41"
        id="linearGradient4547"
-       xlink:href="#linearGradient4541"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4541" />
     <linearGradient
        gradientTransform="matrix(0,1.2221273,-1.2541542,0,1268.4913,-35.107142)"
        gradientUnits="userSpaceOnUse"
@@ -591,8 +160,7 @@
        y1="1007.8622"
        x1="41"
        id="linearGradient4547-0"
-       xlink:href="#linearGradient4541"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4541" />
     <radialGradient
        gradientTransform="translate(-37.999995,-993.36223)"
        gradientUnits="userSpaceOnUse"
@@ -602,8 +170,7 @@
        cy="1004.8622"
        cx="68.5"
        id="radialGradient4587"
-       xlink:href="#linearGradient4581"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient4581" />
     <radialGradient
        gradientUnits="userSpaceOnUse"
        r="1.5"
@@ -613,7 +180,6 @@
        cx="68.5"
        id="radialGradient4587-5"
        xlink:href="#linearGradient4581"
-       inkscape:collect="always"
        gradientTransform="translate(-32.999995,-993.36223)" />
     <radialGradient
        gradientUnits="userSpaceOnUse"
@@ -624,18 +190,7 @@
        cx="68.5"
        id="radialGradient4587-0"
        xlink:href="#linearGradient4581"
-       inkscape:collect="always"
        gradientTransform="translate(-28.000016,-993.36223)" />
-    <linearGradient
-       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)"
-       gradientUnits="userSpaceOnUse"
-       y2="1008.3622"
-       x2="60"
-       y1="1007.8622"
-       x1="41"
-       id="linearGradient5885"
-       xlink:href="#linearGradient4541"
-       inkscape:collect="always" />
     <linearGradient
        y2="1007.8358"
        x2="60.03624"
@@ -644,8 +199,7 @@
        gradientTransform="matrix(-2.055096,0,0,-1.2274096,128.27082,1278.6095)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient5890"
-       xlink:href="#linearGradient5904"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient5904" />
     <linearGradient
        y2="1007.8496"
        x2="59.944244"
@@ -654,120 +208,69 @@
        gradientTransform="matrix(0,-1.3017002,2.1794835,0,-2153.0952,94.443886)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient5892"
-       xlink:href="#linearGradient5898"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient5898" />
     <filter
-       inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter11539"
-       x="-0.05151025"
-       width="1.1030205"
-       y="-0.054155996"
-       height="1.108312">
+       x="-0.063705383"
+       width="1.1274108"
+       y="-0.067055776"
+       height="1.1340333">
       <feGaussianBlur
-         inkscape:collect="always"
          stdDeviation="0.87996598"
          id="feGaussianBlur11541" />
     </filter>
   </defs>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1017"
-     id="namedview10019"
-     showgrid="true"
-     inkscape:snap-nodes="false"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="-0.034940239"
-     inkscape:cy="21.745495"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg10017">
-    <inkscape:grid
-       type="xygrid"
-       id="grid10820" />
-  </sodipodi:namedview>
   <path
      style="opacity:0.50700001;fill:#808080;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter11539)"
      d="m 5.1119183,6.1119183 c 17.8978207,0.108917 40.9999627,0 40.9999627,0 V 45.108862 H 5.1119183 Z"
-     id="rect4001-1-0"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-1-0" />
   <path
      style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none;stroke-width:1"
      d="m 3.9884989,14 40.0229971,2.9e-4 c 0,0 -0.06553,14.85449 0,28.02424 H 3.9884989 Z"
-     id="rect4001-3-4"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4" />
   <path
      style="fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
      d="m 3.5000182,3.5030177 c 17.8978208,0.1089172 40.9999628,0 40.9999628,0 V 42.499962 H 3.5000182 Z"
-     id="rect4001-1"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-1" />
   <path
      style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
      d="m 3.9884989,8.731046 40.0229971,9.51e-5 c 0,0 -0.06553,3.0252359 0,5.7073599 H 3.9884989 Z"
-     id="rect4001-3-4-1"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1" />
   <path
      style="display:inline;fill:url(#linearGradient4467);fill-opacity:1;stroke:none;stroke-width:1"
      d="m 3.9884989,3.9748339 40.0229971,8.37e-5 c 0,0 -0.0655,2.6635894 0,5.0250824 H 3.9884989 Z"
-     id="rect4001-3-4-1-6"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1-6" />
   <path
      style="display:inline;fill:url(#radialGradient4587);fill-opacity:1;stroke:none;stroke-width:1"
      d="m 28.999999,9.9999997 3,1.003e-4 c 0,0 -0.005,1.5901 0,2.9999 h -3 z"
-     id="rect4001-3-4-1-1-8"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1-1-8" />
   <path
-     inkscape:connector-curvature="0"
      id="path4539"
      d="M 4,14.5 H 28.404667"
      style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     inkscape:connector-curvature="0"
      id="path4539-4"
      d="M 4.4765851,15 V 38.220416"
      style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-0);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
      style="display:inline;fill:url(#radialGradient4587-5);fill-opacity:1;stroke:none;stroke-width:1"
      d="m 33.999999,9.9999997 3,1.003e-4 c 0,0 -0.005,1.5901 0,2.9999 h -3 z"
-     id="rect4001-3-4-1-1-8-5"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1-1-8-5" />
   <path
      style="display:inline;fill:url(#radialGradient4587-0);fill-opacity:1;stroke:none;stroke-width:1"
      d="M 38.999999,9.9999997 42,10.0001 c 0,0 -0.005,1.5901 0,2.9999 h -3.000001 z"
-     id="rect4001-3-4-1-1-8-3"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
+     id="rect4001-3-4-1-1-8-3" />
   <path
-     inkscape:connector-curvature="0"
      id="path4539-6"
      d="M 44.011897,41.549766 H 4.9650707"
      style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient5890);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     inkscape:connector-curvature="0"
      id="path4539-4-6"
      d="M 43.523813,41.07424 V 16.341841"
      style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5892);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
      id="layer3"
-     inkscape:label="old"
      transform="translate(-93.974577,-19.169492)" />
   <g
      id="g11331-3-1-1"


### PR DESCRIPTION
## What it does

Cleans up SVG image files from unused contents with Inkscape's cleanup functionality.

The cleanup was executed per script as posted in: https://github.com/eclipse-platform/eclipse.platform.ui/issues/3793#issuecomment-4127257385

## How to test

There should not be any visible changes, i.e., starting a product with this change all icons should still look the same.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
