### PR TITLE
Remove deleted org.eclipse.jdt.launching.macosx Plug-in from JDT feature

### DIFF
--- a/org.eclipse.jdt-feature/feature.xml
+++ b/org.eclipse.jdt-feature/feature.xml
@@ -115,11 +115,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.jdt.launching.macosx"
-         os="macosx"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.jdt.launching.ui.macosx"
          os="macosx"
          version="0.0.0"/>


### PR DESCRIPTION
Part of
- https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/855

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
